### PR TITLE
feat(favorites): add favorite applications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ applications:
       value: 'plex'
     category: 'media'
     openNewTab: true
+    favorite: true
     tags:
       - media
       - streaming

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Each application supports:
 | `category` | `string` | ✅ Yes | - | Category ID to belong to |
 | `openNewTab` | `boolean` | No | `true` | Open in new tab or same window |
 | `tags` | `array[string]` | No | `[]` | Searchable tags |
+| `favorite` | `boolean` | No | `false` | Mark as favorite and show in Favorites category |
 
 **Icon Configuration:**
 
@@ -364,6 +365,7 @@ applications:
       value: 'plex'
     category: 'media'
     openNewTab: true
+    favorite: true
     tags:
       - media
       - streaming

--- a/openspec/changes/favorites-feature/design.md
+++ b/openspec/changes/favorites-feature/design.md
@@ -1,0 +1,99 @@
+# Design: Favorites Feature
+
+## Technical Approach
+
+Add `favorite: boolean` to `SelfhostedAppSchema` (defaults `false`). Introduce `FAVORITES_CATEGORY` as a virtual category, following the existing `APP_CATEGORY`/`BOOKMARKS_CATEGORY` pattern. Derive the visible category list dynamically in `CategoryService`, prepend `FAVORITES_CATEGORY` when at least one app is favorited, and handle filtering via the `favorite` flag in `SearchService` and `AppService`. Consolidate auto-selection and fallback logic into `CategoryService` to eliminate duplication with `AppService`.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives | Rationale |
+|----------|--------|--------------|-----------|
+| Virtual category ordering | Prepend Favorites, then sort remaining categories A-Z | Sort everything A-Z; custom weights | Proposal requires Favorites first; minimal change to existing A-Z behavior |
+| Auto-selection/fallback owner | `CategoryService` | `AppService.apps$` tap | Single responsibility; `CategoryService` already owns category state and derivation |
+| Favorite flag on bookmarks | Out of scope | Add `favorite` to `BookmarkSchema` | Proposal explicitly excludes bookmarks |
+| App category retention | Keep original `category` on favorited apps | Overwrite with `FAVORITES_CATEGORY.id` | Apps must still appear under their real category when not filtering by Favorites |
+
+## Data Flow
+
+```
+dashboard.yaml --→ ConfigService.config$
+                         │
+        ┌────────────────┼────────────────┐
+        │                │                │
+        ▼                ▼                ▼
+ CategoryService    AppService      SearchService
+ categories$         apps$           filterApps()
+   │                  │                ▲
+   │             filteredApps$ ◄───────┘
+   │                  │
+   └────────────► DashboardComponent
+                  AppCategoriesComponent
+```
+
+1. **Config load** → `ConfigService.config$` emits parsed `DashboardConfig`
+2. **Category derivation** → `CategoryService.categories$` builds `[FAVORITES?, Apps?, Bookmarks?, ...userCategories].sort()` and auto-corrects `selectedCategory$` if the current selection disappears
+3. **App aggregation** → `AppService.apps$` emits `[...applications, ...bookmarks(with favorite:false)]`
+4. **Filtering** → `SearchService.filterApps` handles `FAVORITES_CATEGORY.id` by checking `app.favorite === true`
+5. **Rendering** → Components consume `categories$` and `filteredApps$` via `toSignal`
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/app/core/models/dashboard.models.ts` | Modify | Add `favorite: z.boolean().default(false)` to `SelfhostedAppSchema`; add `FAVORITES_CATEGORY` constant |
+| `src/app/core/services/category.service.ts` | Modify | Prepend `FAVORITES_CATEGORY` when `applications.some(a => a.favorite)`; add subscription to fallback selected category |
+| `src/app/core/services/app.service.ts` | Modify | Remove `tap` auto-selection; add `favorite: false` to bookmark mapping; handle `FAVORITES_CATEGORY` in `getAppsByCategory` |
+| `src/app/core/services/search.service.ts` | Modify | Add `categoryId === FAVORITES_CATEGORY.id` branch in `filterApps` |
+| `src/app/core/services/category.service.spec.ts` | Create | Derivation order, dynamic show/hide, fallback logic |
+| `src/app/core/services/app.service.spec.ts` | Create | `apps$` emission, `getAppsByCategory`, `filteredApps$` integration |
+| `src/app/core/services/search.service.spec.ts` | Create | Category filtering including Favorites, search text filtering |
+| `src/app/shared/components/app-categories/app-categories.component.spec.ts` | Modify | Include `FAVORITES_CATEGORY` in mock category lists where appropriate |
+| `src/app/views/dashboard/dashboard.component.spec.ts` | Modify | Update mock `categories$` if test assertions depend on count/order |
+| `README.md` | Modify | Document `favorite` field in applications configuration reference |
+
+## Interfaces / Contracts
+
+```typescript
+// dashboard.models.ts
+export const FAVORITES_CATEGORY: Category = {
+  id: 'favorites',
+  name: 'Favorites',
+};
+
+export const SelfhostedAppSchema = z.object({
+  // ...existing fields
+  favorite: z.boolean().default(false),
+});
+```
+
+**CategoryService.categories$ contract**: Emits ordered list where `FAVORITES_CATEGORY` is at index 0 when `config.applications.some(a => a.favorite)`, otherwise omitted.
+
+**CategoryService.selectedCategory$ contract**: Automatically falls back to the first visible category ID whenever the current selection is no longer present in `categories$`.
+
+**SearchService.filterApps contract**: When `categoryId === 'favorites'`, returns only apps where `favorite === true`.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | `CategoryService.categories$` | `TestBed` with mocked `ConfigService`; assert Favorites prepended only when favorites exist |
+| Unit | `CategoryService` fallback | Emit config removing favorites while Favorites is selected; assert selection falls back to first visible category |
+| Unit | `AppService.apps$` | Mock `ConfigService` + `BookmarkService`; assert bookmarks receive `favorite: false` |
+| Unit | `AppService.getAppsByCategory` | Direct service method calls; assert Favorites returns only `favorite: true` apps |
+| Unit | `SearchService.filterApps` | Direct method calls; assert Favorites + search query combinations |
+| Integration | `AppService.filteredApps$` | `TestBed`; assert combineLatest of `apps$`, search, and category produces correct filtered arrays |
+| Component | `app-categories` | Update mocks; verify `aria-pressed` and click behavior with Favorites present |
+
+## Migration / Rollout
+
+No migration required. `favorite` defaults to `false`, so existing `dashboard.yaml` files without the field remain valid. Removing `favorite` fields is a backward-compatible rollback.
+
+## Accessibility Considerations
+
+- **Dynamic tabs**: `app-categories` uses `@for (track category.id)`. Focus is preserved when Favorites appears/disappears because Angular's reconciliation maintains button identity.
+- **aria-pressed**: The Favorites button receives `aria-pressed` automatically via the existing binding.
+- **AXE**: Verify zero violations after implementation; dynamic content insertion at the head of a navigation region is acceptable when focus is not forcibly moved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/favorites-feature/exploration.md
+++ b/openspec/changes/favorites-feature/exploration.md
@@ -1,0 +1,162 @@
+# Exploration: Favorites Feature
+
+## Current State
+
+getmando is an Angular 21 dashboard that renders self-hosted apps from a `dashboard.yaml` configuration. The data flow is:
+
+1. `YamlParserService` parses YAML → `DashboardConfig` (Zod-validated)
+2. `ConfigService` emits the config via `BehaviorSubject`
+3. `CategoryService` derives visible categories: `[Apps (optional), Bookmarks (optional), ...user categories sorted A-Z]`
+4. `AppService.apps$` merges `applications` + `bookmarks` (if `allowBookmarks`) into a flat list sorted by name
+5. `AppService.filteredApps$` combines `apps$`, `searchQuery$`, `selectedCategory$` and calls `SearchService.filterApps`
+6. `DashboardComponent` renders the grid; `AppCategoriesComponent` renders category tabs
+
+There is **no concept of favorites** today. Categories are entirely driven by the `category` field on each app. Bookmarks are a separate entity without a `category` field (they get `BOOKMARKS_CATEGORY.id` injected at runtime).
+
+## Affected Areas
+
+| File | Why Affected |
+|------|-------------|
+| `src/app/core/models/dashboard.models.ts` | Add `favorite` to `SelfhostedAppSchema`; add `FAVORITES_CATEGORY` constant |
+| `src/app/core/services/category.service.ts` | Dynamically prepend `FAVORITES_CATEGORY` when ≥1 favorite app exists |
+| `src/app/core/services/app.service.ts` | Handle `FAVORITES_CATEGORY` in `getAppsByCategory`; fix `showAllCategory=false` auto-selection logic |
+| `src/app/core/services/search.service.ts` | Handle `FAVORITES_CATEGORY` in `filterApps` |
+| `src/app/shared/components/app-categories/app-categories.component.spec.ts` | Update mocks/tests if category list behavior changes |
+| `src/app/views/dashboard/dashboard.component.spec.ts` | Update mocks if new category constant is referenced |
+| `README.md` | Document the new `favorite` field in the applications reference table |
+
+## Approaches
+
+### Option A — Virtual Favorites Category (Recommended)
+
+Treat "Favorites" as a derived, virtual category (exactly like "Apps" and "Bookmarks"). No schema changes beyond adding `favorite: boolean`. The category appears dynamically when at least one app is favorited.
+
+**Changes:**
+- `SelfhostedAppSchema`: add `favorite: z.boolean().default(false)`
+- `dashboard.models.ts`: add `FAVORITES_CATEGORY: Category = {id: 'favorites', name: 'Favorites'}`
+- `CategoryService.categories$`: if `applications.some(a => a.favorite)`, prepend `FAVORITES_CATEGORY`
+- `SearchService.filterApps`: if `categoryId === FAVORITES_CATEGORY.id`, filter by `app.favorite === true`
+- `AppService.getAppsByCategory`: same logic
+- `AppService.apps$` tap: if `!showAllCategory`, select first visible category (not `config.categories[0]`). Derive this by checking if favorites exist.
+
+**Pros:**
+- Minimal footprint; follows existing virtual-category pattern (Apps, Bookmarks)
+- No new settings needed
+- Backward-compatible: existing configs without `favorite` default to `false`
+
+**Cons:**
+- Category order logic becomes slightly more complex
+- Favorites category disappears/reappears dynamically as config changes
+
+**Effort:** Low
+
+### Option B — Settings-Gated Favorites
+
+Add a `showFavorites: boolean` setting (default `true`). The Favorites category is only shown when this setting is enabled AND favorites exist.
+
+**Pros:**
+- Users can explicitly disable the feature
+- More predictable behavior
+
+**Cons:**
+- Overkill for the requested feature
+- Adds UI bloat (no settings panel exists today for per-feature toggles)
+- Not what the user asked for
+
+**Effort:** Medium
+
+### Option C — Favorites as a Separate Data Structure
+
+Store favorites as an array of IDs or a separate `favorites` section in the YAML, then cross-reference at runtime.
+
+**Pros:**
+- Keeps app schema smaller
+
+**Cons:**
+- Breaks the intuitive "per-app" configuration style
+- More complex YAML authoring
+- Requires validation that IDs exist
+
+**Effort:** Medium
+
+## Recommendation
+
+**Option A — Virtual Favorites Category.**
+
+It aligns perfectly with how "Apps" and "Bookmarks" are already implemented as virtual categories. The user's mental model ("each application supports `favorite: true/false`") maps directly to a boolean field on the app. The dynamic appearance of the category is acceptable because the config is loaded at startup; it won't flicker in normal use.
+
+## Data Flow (Option A)
+
+```
+dashboard.yaml
+  applications:
+    - id: plex
+      favorite: true
+      ...
+
+YamlParserService.parseYaml()
+  → DashboardConfig.applications[0].favorite === true
+
+ConfigService.config$
+  → CategoryService.categories$
+    → [FAVORITES_CATEGORY, APP_CATEGORY, ...user categories]  (favorites exist)
+    → [APP_CATEGORY, ...user categories]                     (no favorites)
+
+AppService.apps$
+  → [all apps + bookmarks] sorted by name
+
+AppService.filteredApps$
+  → SearchService.filterApps(apps, query, categoryId)
+    → if categoryId === 'favorites': apps.filter(a => a.favorite === true)
+    → else: existing behavior
+```
+
+## UI/UX Considerations
+
+1. **Category Order**: Favorites MUST appear **first** in the category list (before Apps). The rationale: favorites are the user's most-curated subset; they should be the most accessible.
+
+2. **Dynamic Visibility**: The Favorites tab SHOULD only appear when at least one app is favorited. An empty Favorites category is confusing and wastes UI space.
+
+3. **Default Selection When `showAllCategory: false`**: Currently, when `showAllCategory` is false, the app auto-selects `config.categories[0].id`. If favorites exist, the first visible category is now Favorites, so the auto-selection logic MUST be updated.
+
+4. **Search Behavior**: During active search, categories are disabled and all apps are searched. Favorited apps MUST still appear in search results (they are part of the flat apps list). The `filterApps` method handles this correctly because `searchAll = true` bypasses category filtering.
+
+5. **Empty State**: If the user selects Favorites and then removes all favorites from the YAML (or loads a config with no favorites), the Favorites tab disappears. Angular's change detection will re-render the category list. The dashboard will show the "No applications found" empty state if Favorites was the selected category and it disappears. To mitigate this, `CategoryService` or `AppService` should reset the selected category to the first remaining visible category when Favorites disappears.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No favorites in config | Favorites category is **hidden** entirely |
+| `showAllCategory: false` + favorites exist | Auto-select **Favorites** (first visible category) |
+| `showAllCategory: false` + no favorites | Auto-select first user-defined category (existing behavior) |
+| Search active | Categories disabled; favorited apps appear in search normally |
+| All favorites removed at runtime (config reload) | Favorites tab disappears; selected category SHOULD fall back to next visible category |
+| Bookmarks | Bookmarks do **not** support `favorite` (out of scope; BookmarkSchema is separate) |
+| Duplicate app names in favorites | Allowed; sorted alphabetically within Favorites like any other category |
+
+## Accessibility Considerations
+
+1. **Dynamic Category List**: When Favorites appears/disappears, screen readers SHOULD be informed. The existing `<nav aria-label="Categories">` with `@for` rendering is sufficient because Angular re-renders the full list; screen readers will detect DOM changes. However, we SHOULD ensure focus management doesn't break: if a user has focus on the Favorites button and it disappears, focus will be lost. This is an edge case (requires config reload while focused), but worth noting.
+
+2. **ARIA Pressed State**: Category buttons already use `aria-pressed`. No change needed.
+
+3. **Keyboard Navigation**: The category list is a `<nav>` containing `<button>` elements. Tab order is natural. No change needed.
+
+4. **Color Contrast / Visual Distinction**: Consider whether Favorites should have a visual distinction (e.g., a star icon). This is a design decision for the `sdd-design` phase. At minimum, the text "Favorites" is sufficient for WCAG AA.
+
+5. **Empty State Accessibility**: The existing empty state (`role="list"` replaced by a `<section>` with heading and paragraph) is accessible. No change needed.
+
+## Testing Impact
+
+- `app-categories.component.spec.ts`: Mocks `CategoryService.categories$`. Tests need to account for Favorites appearing when mocks include a favorited app.
+- `dashboard.component.spec.ts`: Mocks `CategoryService.categories$` with `[APP_CATEGORY]`. If favorites are added to mock data, the test setup should still work because the mock explicitly controls `categories$`.
+- **New tests recommended** for `CategoryService`, `SearchService`, and `AppService` to cover favorites logic, though no spec files exist for these services today.
+- Since `strict_tdd: true` in `openspec/config.yaml`, any implementation MUST include tests.
+
+## Open Questions for Design/Spec Phase
+
+1. Should the Favorites category have a visual indicator (star icon)?
+2. Should favorited apps ALSO appear in their original category, or ONLY in Favorites? (Assumption: they appear in BOTH — the current flat apps list + category filtering means an app is always in the "Apps" category and its own category; Favorites is just another filter.)
+3. Should bookmarks support favorites in a future iteration?
+4. Should there be a `showFavorites` setting? (User didn't ask for it; defer.)

--- a/openspec/changes/favorites-feature/proposal.md
+++ b/openspec/changes/favorites-feature/proposal.md
@@ -1,0 +1,75 @@
+# Proposal: Favorites Feature
+
+## Intent
+
+Allow users to mark applications as favorites in `dashboard.yaml` via a `favorite: true/false` flag. Favorited apps are grouped under a dynamic **Favorites** virtual category that appears automatically when at least one favorite exists.
+
+## Scope
+
+### In Scope
+- Add `favorite` boolean to `SelfhostedAppSchema` (defaults to `false`)
+- Introduce `FAVORITES_CATEGORY` constant and virtual category logic
+- Update `CategoryService`, `AppService`, and `SearchService` to derive and filter the Favorites category
+- Adjust default category selection when `showAllCategory: false`
+- Update component tests and add service-level unit tests (strict TDD)
+- Document the new field in `README.md`
+
+### Out of Scope
+- Favorite support for bookmarks
+- Settings toggle to disable Favorites
+- Visual star icons or design tokens (deferred to design phase)
+
+## Capabilities
+
+### New Capabilities
+- `app-favorites`: Per-application favorite flag with dynamic virtual category grouping
+
+### Modified Capabilities
+- None
+
+## Approach
+
+**Virtual Favorites Category** — follows the existing `APP_CATEGORY` and `BOOKMARKS_CATEGORY` pattern.
+
+- `favorite` defaults to `false`, preserving backward compatibility
+- `FAVORITES_CATEGORY` is injected at the **head** of the derived category list when `applications.some(a => a.favorite)`
+- `SearchService.filterApps` and `AppService.getAppsByCategory` filter by `app.favorite === true` when the Favorites category is active
+- `AppService.apps$` tap selects the **first visible category** (not hard-coded `config.categories[0]`) when `showAllCategory` is disabled
+- If Favorites disappears at runtime (config reload), selection falls back to the first remaining visible category
+
+## Affected Areas
+
+| File | Impact |
+|------|--------|
+| `src/app/core/models/dashboard.models.ts` | Add `favorite` to schema; add `FAVORITES_CATEGORY` constant |
+| `src/app/core/services/category.service.ts` | Prepend `FAVORITES_CATEGORY` dynamically |
+| `src/app/core/services/app.service.ts` | Handle Favorites in `getAppsByCategory`; fix auto-selection logic |
+| `src/app/core/services/search.service.ts` | Handle `FAVORITES_CATEGORY` in `filterApps` |
+| `src/app/shared/components/app-categories/app-categories.component.spec.ts` | Update mocks for dynamic category list |
+| `src/app/views/dashboard/dashboard.component.spec.ts` | Update mocks if needed |
+| `README.md` | Document `favorite` field |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| No existing service-level unit tests | High | Create specs for `CategoryService`, `SearchService`, and `AppService` as part of this change |
+| Favorites category disappears while selected | Low | Auto-fallback to first visible category on category list change |
+| Accessibility regressions from dynamic tabs | Low | Verify `aria-pressed`, focus order, and AXE checks after implementation |
+
+## Rollback Plan
+
+Revert the commits or remove `favorite` fields from `dashboard.yaml`. The schema default (`false`) ensures the app remains functional without config changes.
+
+## Dependencies
+
+None.
+
+## Success Criteria
+
+- [ ] `favorite: true` in YAML causes the Favorites category to appear **first** in the category list
+- [ ] Favorites category is **hidden** when no apps are favorited
+- [ ] Selecting Favorites shows only favorited apps
+- [ ] `showAllCategory: false` auto-selects Favorites when favorites exist
+- [ ] All new and existing tests pass under `strict_tdd`
+- [ ] AXE audit passes with zero violations

--- a/openspec/changes/favorites-feature/verify-report.md
+++ b/openspec/changes/favorites-feature/verify-report.md
@@ -1,0 +1,159 @@
+## Verification Report
+
+**Change**: favorites-feature
+**Version**: N/A
+**Mode**: Strict TDD
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 14 |
+| Tasks complete | 14 |
+| Tasks incomplete | 0 |
+
+All tasks from the task breakdown are marked complete. No incomplete tasks remain.
+
+---
+
+### Build & Tests Execution
+
+**Build**: ⚠️ Passed with warning
+```
+Application bundle generation complete.
+▲ [WARNING] bundle initial exceeded maximum budget. Budget 500.00 kB was not met by 174.68 kB with a total of 674.68 kB.
+```
+The bundle budget warning is pre-existing and unrelated to the favorites feature.
+
+**Tests**: ✅ 51 passed / ❌ 0 failed / ⚠️ 0 skipped
+```
+Test Files  8 passed (8)
+Tests       51 passed (51)
+Duration    2.25s
+```
+
+**Coverage**: ➖ Not available — `@vitest/coverage-v8` is not installed.
+
+---
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | Found in apply-progress artifact |
+| All tasks have tests | ✅ | 4 tasks have test files; structural task 1.1 correctly skipped |
+| RED confirmed (tests exist) | ✅ | 4/4 test files verified in codebase |
+| GREEN confirmed (tests pass) | ✅ | All 51 tests pass on execution |
+| Triangulation adequate | ✅ | 5 + 3 + 5 + 1 = 14 cases across new test files |
+| Safety Net for modified files | ✅ | app-categories: 5/5 existing passed before modification |
+
+**TDD Compliance**: 6/6 checks passed
+
+---
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 13 new | 3 new | Angular TestBed + Vitest |
+| Integration | 1 new | 1 modified | @testing-library/angular |
+| E2E | 0 | 0 | not installed |
+| **Total new** | **14** | **4** | |
+
+**Note**: Changed files also contain 24 pre-existing integration tests across 3 component spec files.
+
+---
+
+### Changed File Coverage
+Coverage analysis skipped — `@vitest/coverage-v8` is not installed.
+
+---
+
+### Assertion Quality
+| File | Line | Assertion | Issue | Severity |
+|------|------|-----------|-------|----------|
+| `app-categories.component.spec.ts` | 95 | `expect(categoriesNav).not.toHaveClass('opacity-50')` | CSS class assertion — implementation detail coupling | WARNING (pre-existing) |
+| `app-categories.component.spec.ts` | 101 | `expect(categoriesNav).toHaveClass('opacity-50')` | CSS class assertion — implementation detail coupling | WARNING (pre-existing) |
+| `app-categories.component.spec.ts` | 118 | `expect(mediaButton).toHaveClass('bg-white/10', 'border-white/50')` | CSS class assertion — implementation detail coupling | WARNING (pre-existing) |
+| `app-categories.component.spec.ts` | 125 | `expect(appsButton).toHaveClass('bg-white/10', 'border-white/50')` | CSS class assertion — implementation detail coupling | WARNING (pre-existing) |
+
+**Assertion quality**: 0 CRITICAL, 4 WARNING (all pre-existing in modified file)
+No tautologies, ghost loops, mock-heavy tests, or type-only assertions found in new test code.
+
+---
+
+### Quality Metrics
+**Linter**: ➖ Not available — no linter configured in the project.
+**Type Checker**: ✅ No errors (`npx tsc --noEmit` passed)
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Schema | Default parsing | (none found) | ❌ UNTESTED |
+| Category Derivation | Favorites visible | `category.service.spec.ts > should prepend FAVORITES_CATEGORY as the first category when at least one app is favorited` | ✅ COMPLIANT |
+| Category Derivation | Favorites hidden | `category.service.spec.ts > should omit FAVORITES_CATEGORY when no apps are favorited` | ✅ COMPLIANT |
+| Category Derivation | Category order | `category.service.spec.ts > should place virtual categories first, followed by user categories sorted A-Z` | ✅ COMPLIANT |
+| App Filtering | Filter by favorites | `search.service.spec.ts > should return only favorited apps when categoryId is FAVORITES_CATEGORY.id` | ✅ COMPLIANT |
+| App Filtering | Search bypasses category filter | `search.service.spec.ts > should bypass category filter when searchAll is true` | ✅ COMPLIANT |
+| App Filtering | Original category still shows favorited apps | `search.service.spec.ts > should still include favorited apps in their original category` | ✅ COMPLIANT |
+| Default Selection | Favorites is first visible | `category.service.spec.ts > should select FAVORITES_CATEGORY as first visible when showAllCategory is false and favorites exist` | ✅ COMPLIANT |
+| Default Selection | No favorites fallback | `category.service.spec.ts > should auto-select the first visible category when the current selection disappears` | ⚠️ PARTIAL |
+| Default Selection | Runtime disappearance | `category.service.spec.ts > should auto-select the first visible category when the current selection disappears` | ✅ COMPLIANT |
+| Test Coverage | CategoryService favorites | `category.service.spec.ts` (5 tests) | ✅ COMPLIANT |
+| Test Coverage | SearchService favorites filter | `search.service.spec.ts` (5 tests) | ✅ COMPLIANT |
+| Documentation | README updated | `README.md` (manual verification) | ✅ COMPLIANT |
+
+**Compliance summary**: 11/13 scenarios compliant, 1 partial, 1 untested
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Schema: `favorite` boolean with default `false` | ✅ Implemented | `SelfhostedAppSchema` line 23; `FAVORITES_CATEGORY` lines 120-123 |
+| Category Derivation: prepend Favorites when ≥1 favorite | ✅ Implemented | `category.service.ts` lines 19-21 |
+| Category Derivation: virtuals before user categories A-Z | ✅ Implemented | `category.service.ts` lines 31-34 |
+| App Filtering: Favorites category returns only `favorite === true` | ✅ Implemented | `search.service.ts` lines 71-72; `app.service.ts` lines 124-126 |
+| App Filtering: search bypasses category filter | ✅ Implemented | `search.service.ts` lines 66-67 |
+| App Filtering: original category retains favorited apps | ✅ Implemented | `search.service.ts` lines 74; `app.service.ts` lines 128 |
+| Default Selection: auto-select first visible category | ✅ Implemented | `category.service.ts` constructor lines 40-45 |
+| Bookmarks receive `favorite: false` | ✅ Implemented | `app.service.ts` lines 42-45 |
+| Test Coverage: service unit tests | ✅ Implemented | 3 new spec files created |
+| Documentation: `favorite` field in README | ✅ Implemented | Line 344 and Plex example line 368 |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Virtual category ordering: Prepend Favorites, then A-Z | ✅ Yes | Exact implementation in `category.service.ts` |
+| Auto-selection/fallback owner: `CategoryService` | ✅ Yes | Fallback moved from `AppService` to `CategoryService` constructor subscription |
+| Favorite flag on bookmarks: Out of scope | ✅ Yes | Bookmarks explicitly get `favorite: false` in `AppService.apps$` |
+| App category retention: Keep original `category` | ✅ Yes | Favorited apps retain their original `category` field |
+| File Changes table | ✅ Yes | All files from design were created/modified as specified |
+
+**Deviation**: `CategoryService` fallback uses constructor `.subscribe()` instead of `tap` on `categories$`. Rationale (from apply-progress): `categories$` is a cold observable; the `tap` only executes when subscribed. The fallback must run eagerly whenever config changes, regardless of whether any component is currently subscribed to `categories$`. This deviation is architecturally sound and correctly implements the design intent.
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+1. **Schema default parsing scenario is untested** — The spec requires a test proving that an application without `favorite` in YAML parses to `favorite: false`. While this is Zod `.default(false)` library behavior, the spec scenario has no corresponding test. In Strict TDD mode, every spec scenario must have a passing test.
+
+**WARNING** (should fix):
+1. **No favorites fallback scenario is only partially tested** — The "No favorites fallback" scenario (initial config with `showAllCategory: false` and zero favorites) is not explicitly tested. The existing fallback test proves runtime disappearance but not the initial load condition. A dedicated test should initialize `CategoryService` with a config that has no favorites and `showAllCategory: false`, then assert the first user category is selected.
+2. **Pre-existing CSS class assertions in `app-categories.component.spec.ts`** — The modified file contains `toHaveClass('opacity-50')` and `toHaveClass('bg-white/10', 'border-white/50')` assertions. These are implementation-detail coupling (Tailwind class names). They were pre-existing, but the file was modified by this change.
+
+**SUGGESTION** (nice to have):
+1. **Add coverage tooling** — Installing `@vitest/coverage-v8` would enable per-file coverage reporting for future changes.
+2. **Add `favorite` to BookmarkSchema for future extensibility** — The design explicitly excluded this, but if bookmarks ever need favorites, the schema would need updating.
+
+---
+
+### Verdict
+PASS WITH WARNINGS
+
+All 14 tasks are complete, all 51 tests pass, the build succeeds, and TypeScript compiles cleanly. The implementation structurally matches the spec and design. Two spec scenarios lack full behavioral test coverage (Schema default parsing and No favorites fallback initial condition), which is flagged as CRITICAL and WARNING respectively. The CRITICAL issue should be addressed before archive by adding a test for the schema default parsing scenario.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,61 @@
+schema: spec-driven
+
+context: |
+  Tech stack: Angular 21 + TypeScript 5.9 + TailwindCSS 4 + Vite
+  Architecture: Standalone components, signals, OnPush, lazy loading
+  Testing: Vitest + @testing-library/angular + jsdom
+  Style: Prettier (printWidth 100, singleQuote), strict TypeScript
+
+strict_tdd: true
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected modules/packages
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group tasks by phase (infrastructure, implementation, testing)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing code patterns and conventions
+    - Load relevant coding skills for the project stack
+  verify:
+    - Run tests if test infrastructure exists
+    - Compare implementation against every spec scenario
+  archive:
+    - Warn before merging destructive deltas (large removals)
+
+testing:
+  strict_tdd: true
+  runner:
+    command: ng test
+    framework: Vitest
+  layers:
+    unit:
+      available: true
+      tool: "@testing-library/angular + jsdom"
+    integration:
+      available: true
+      tool: "@testing-library/angular + jsdom"
+    e2e:
+      available: false
+      tool: null
+  coverage:
+    available: false
+    command: null
+  quality:
+    linter:
+      available: false
+      command: null
+    type_checker:
+      available: true
+      command: "tsc --noEmit"
+    formatter:
+      available: true
+      command: prettier

--- a/openspec/specs/app-favorites/spec.md
+++ b/openspec/specs/app-favorites/spec.md
@@ -1,0 +1,96 @@
+# App Favorites Specification
+
+## Purpose
+Allow users to mark applications as favorites in `dashboard.yaml` via a `favorite` boolean. Favorited apps are grouped under a dynamic virtual **Favorites** category that appears automatically when at least one favorite exists.
+
+## Requirements
+
+### Requirement: Schema
+The system MUST support a `favorite` boolean field on each application, defaulting to `false`. The system MUST expose `FAVORITES_CATEGORY` as a virtual category constant (`id: 'favorites'`, `name: 'Favorites'`).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `favorite` | `boolean` | `false` | Marks app as favorited |
+
+#### Scenario: Default parsing
+- GIVEN an application without `favorite` in YAML
+- WHEN the config is parsed
+- THEN `favorite` equals `false`
+
+### Requirement: Category Derivation
+The system MUST include `FAVORITES_CATEGORY` as the first category when at least one application has `favorite: true`. Virtual categories MUST appear before user-defined categories; user-defined categories MUST be sorted A-Z.
+
+#### Scenario: Favorites visible
+- GIVEN ≥1 app with `favorite: true`
+- WHEN `categories$` emits
+- THEN `FAVORITES_CATEGORY` is first
+
+#### Scenario: Favorites hidden
+- GIVEN zero favorited apps
+- WHEN `categories$` emits
+- THEN `FAVORITES_CATEGORY` is absent
+
+#### Scenario: Category order
+- GIVEN `showAllCategory: true` and `allowBookmarks: true`
+- WHEN `categories$` emits
+- THEN virtuals appear first, followed by user categories sorted A-Z
+
+### Requirement: App Filtering
+The system MUST filter apps by `favorite === true` when `FAVORITES_CATEGORY` is active. Bookmarks MUST NOT support favorites.
+
+#### Scenario: Filter by favorites
+- GIVEN `categoryId === 'favorites'`
+- WHEN `filterApps` executes
+- THEN only apps with `favorite === true` are returned
+
+#### Scenario: Search bypasses category filter
+- GIVEN active search query and `searchAll === true`
+- WHEN `filterApps` executes
+- THEN all matching apps are returned regardless of favorite status
+
+#### Scenario: Original category still shows favorited apps
+- GIVEN an app with `favorite: true` and `category: 'media'`
+- WHEN Media category is selected
+- THEN the app is included
+
+### Requirement: Default Selection
+When `showAllCategory` is `false`, the system MUST auto-select the first visible category.
+
+#### Scenario: Favorites is first visible
+- GIVEN `showAllCategory: false` and favorites exist
+- WHEN config initializes
+- THEN `FAVORITES_CATEGORY` is selected
+
+#### Scenario: No favorites fallback
+- GIVEN `showAllCategory: false` and no favorites
+- WHEN config initializes
+- THEN the first user-defined category is selected
+
+#### Scenario: Runtime disappearance
+- GIVEN Favorites is selected and all favorites are removed
+- WHEN config reloads
+- THEN selection falls back to the first remaining visible category
+
+### Requirement: Test Coverage
+The system MUST include unit tests for `CategoryService`, `AppService`, and `SearchService` covering favorites logic.
+
+#### Scenario: CategoryService favorites
+- GIVEN favorited apps exist
+- WHEN `categories$` is subscribed
+- THEN `FAVORITES_CATEGORY` is first
+
+#### Scenario: SearchService favorites filter
+- GIVEN mixed favorited and non-favorited apps
+- WHEN filtering by Favorites category
+- THEN only favorited apps are returned
+
+### Requirement: Documentation
+The `favorite` field MUST be documented in `README.md` under the applications reference table.
+
+## Non-Functional Requirements
+
+### Accessibility
+Dynamic addition or removal of the Favorites category MUST pass AXE checks with zero violations. Focus order MUST remain logical.
+
+### Performance
+Category derivation and app filtering latency MUST remain under 50ms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4367,31 +4367,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4400,7 +4400,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4412,26 +4412,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4439,13 +4439,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4454,9 +4455,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4464,18 +4465,26 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -5520,9 +5529,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8656,9 +8665,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8821,9 +8830,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9120,31 +9129,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -9160,12 +9169,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -9186,6 +9198,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -9194,6 +9212,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/src/app/core/models/dashboard.models.ts
+++ b/src/app/core/models/dashboard.models.ts
@@ -20,6 +20,7 @@ export const SelfhostedAppSchema = z.object({
   category: z.string(),
   openNewTab: z.boolean().default(true),
   tags: z.array(z.string()).default([]),
+  favorite: z.boolean().default(false),
 });
 
 /**
@@ -114,6 +115,11 @@ export const APP_CATEGORY: Category = {
 export const BOOKMARKS_CATEGORY: Category = {
   id: 'bookmarks',
   name: 'Bookmarks',
+};
+
+export const FAVORITES_CATEGORY: Category = {
+  id: 'favorites',
+  name: 'Favorites',
 };
 
 export const DEFAULT_DASHBOARD_CONFIG: DashboardConfig = {

--- a/src/app/core/services/app.service.spec.ts
+++ b/src/app/core/services/app.service.spec.ts
@@ -1,0 +1,180 @@
+import {TestBed} from '@angular/core/testing';
+import {BehaviorSubject, firstValueFrom} from 'rxjs';
+
+import {AppService} from './app.service';
+import {ConfigService} from './config.service';
+import {BookmarkService} from './bookmark.service';
+import {SearchService} from './search.service';
+import {CategoryService} from './category.service';
+import {YamlLoaderService} from './yaml-loader.service';
+
+import {
+  APP_CATEGORY,
+  BOOKMARKS_CATEGORY,
+  FAVORITES_CATEGORY,
+  DashboardConfig,
+  DEFAULT_DASHBOARD_CONFIG,
+  SelfhostedApp,
+} from '../models/dashboard.models';
+
+describe('AppService', () => {
+  let service: AppService;
+  let configSubject: BehaviorSubject<DashboardConfig>;
+  let searchService: SearchService;
+  let categoryService: CategoryService;
+
+  const createConfig = (overrides: Partial<DashboardConfig> = {}): DashboardConfig => ({
+    ...DEFAULT_DASHBOARD_CONFIG,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    configSubject = new BehaviorSubject<DashboardConfig>(createConfig());
+
+    TestBed.configureTestingModule({
+      providers: [
+        AppService,
+        SearchService,
+        CategoryService,
+        {
+          provide: ConfigService,
+          useValue: {
+            config$: configSubject.asObservable(),
+            subject: configSubject,
+            fireNewSubject: (config: DashboardConfig) => configSubject.next(config),
+          },
+        },
+        {
+          provide: YamlLoaderService,
+          useValue: {
+            loadDashboardConfig: () => new BehaviorSubject(createConfig()),
+          },
+        },
+        {
+          provide: BookmarkService,
+          useValue: {
+            bookmarks: [],
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(AppService);
+    searchService = TestBed.inject(SearchService);
+    categoryService = TestBed.inject(CategoryService);
+  });
+
+  describe('apps$', () => {
+    it('should assign favorite: false to bookmarks when allowBookmarks is true', async () => {
+      const bookmarkServiceMock = TestBed.inject(BookmarkService);
+      (bookmarkServiceMock as unknown as {bookmarks: unknown[]}).bookmarks = [
+        {
+          id: 'google',
+          name: 'Google',
+          description: 'Search engine',
+          url: 'https://google.com',
+          icon: {type: 'name', value: 'google'},
+          openNewTab: true,
+          tags: [],
+        },
+      ];
+
+      configSubject.next(
+        createConfig({
+          applications: [],
+          bookmarks: [
+            {
+              id: 'google',
+              name: 'Google',
+              description: 'Search engine',
+              url: 'https://google.com',
+              icon: {type: 'name', value: 'google'},
+              openNewTab: true,
+              tags: [],
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            allowBookmarks: true,
+          },
+        }),
+      );
+
+      const apps = await firstValueFrom(service.apps$);
+      expect(apps).toHaveLength(1);
+      expect(apps[0].favorite).toBe(false);
+      expect(apps[0].category).toBe(BOOKMARKS_CATEGORY.id);
+    });
+  });
+
+  describe('getAppsByCategory', () => {
+    it('should return only favorite apps when categoryId is FAVORITES_CATEGORY.id', () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+            {
+              id: 'radarr',
+              name: 'Radarr',
+              description: '',
+              url: 'https://radarr.example.com',
+              icon: {type: 'name', value: 'radarr'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: false,
+            },
+          ],
+        }),
+      );
+
+      const apps = service.getAppsByCategory(FAVORITES_CATEGORY.id);
+      expect(apps).toHaveLength(1);
+      expect(apps[0].id).toBe('plex');
+    });
+
+    it('should return all apps for APP_CATEGORY regardless of favorite status', () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+            {
+              id: 'radarr',
+              name: 'Radarr',
+              description: '',
+              url: 'https://radarr.example.com',
+              icon: {type: 'name', value: 'radarr'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: false,
+            },
+          ],
+        }),
+      );
+
+      const apps = service.getAppsByCategory(APP_CATEGORY.id);
+      expect(apps).toHaveLength(2);
+    });
+  });
+});

--- a/src/app/core/services/app.service.ts
+++ b/src/app/core/services/app.service.ts
@@ -9,6 +9,7 @@ import {
   SelfhostedApp,
   APP_CATEGORY,
   BOOKMARKS_CATEGORY,
+  FAVORITES_CATEGORY,
 } from '../models/dashboard.models';
 
 import {YamlLoaderService} from './yaml-loader.service';
@@ -35,17 +36,13 @@ export class AppService {
    * Observable streams for component consumption
    */
   readonly apps$ = this.configService.config$.pipe(
-    tap((config) => {
-      if (!config.settings.showAllCategory) {
-        this.categoryService.setSelectedCategory(config.categories[0].id);
-      }
-    }),
     map((config) => [
       ...config.applications,
       ...(config.settings.allowBookmarks
         ? this.bookmarkService.bookmarks.map((bookmark) => ({
             ...bookmark,
             category: BOOKMARKS_CATEGORY.id,
+            favorite: false,
           }))
         : []
       ).sort((a, b) => a.name.localeCompare(b.name)),
@@ -122,6 +119,10 @@ export class AppService {
 
     if (categoryId === APP_CATEGORY.id) {
       return this.config.applications;
+    }
+
+    if (categoryId === FAVORITES_CATEGORY.id) {
+      return this.config.applications.filter((app) => app.favorite);
     }
 
     return this.config.applications.filter((app) => app.category === categoryId);

--- a/src/app/core/services/category.service.spec.ts
+++ b/src/app/core/services/category.service.spec.ts
@@ -1,0 +1,276 @@
+import {TestBed} from '@angular/core/testing';
+import {BehaviorSubject, firstValueFrom} from 'rxjs';
+
+import {CategoryService} from './category.service';
+import {ConfigService} from './config.service';
+
+import {
+  APP_CATEGORY,
+  BOOKMARKS_CATEGORY,
+  FAVORITES_CATEGORY,
+  DashboardConfig,
+  DEFAULT_DASHBOARD_CONFIG,
+} from '../models/dashboard.models';
+
+describe('CategoryService', () => {
+  let service: CategoryService;
+  let configSubject: BehaviorSubject<DashboardConfig>;
+
+  const createConfig = (overrides: Partial<DashboardConfig> = {}): DashboardConfig => ({
+    ...DEFAULT_DASHBOARD_CONFIG,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    configSubject = new BehaviorSubject<DashboardConfig>(createConfig());
+
+    TestBed.configureTestingModule({
+      providers: [
+        CategoryService,
+        {
+          provide: ConfigService,
+          useValue: {
+            config$: configSubject.asObservable(),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(CategoryService);
+  });
+
+  describe('categories$', () => {
+    it('should prepend FAVORITES_CATEGORY as the first category when at least one app is favorited', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: true,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      const categories = await firstValueFrom(service.categories$);
+      expect(categories[0]).toEqual(FAVORITES_CATEGORY);
+      expect(categories.map((c) => c.id)).toEqual(['favorites', 'apps', 'media']);
+    });
+
+    it('should omit FAVORITES_CATEGORY when no apps are favorited', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: false,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: true,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      const categories = await firstValueFrom(service.categories$);
+      expect(categories.some((c) => c.id === FAVORITES_CATEGORY.id)).toBe(false);
+      expect(categories.map((c) => c.id)).toEqual(['apps', 'media']);
+    });
+
+    it('should place virtual categories first, followed by user categories sorted A-Z', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: true,
+            allowBookmarks: true,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+            {id: 'dev', name: 'Development'},
+          ],
+        }),
+      );
+
+      const categories = await firstValueFrom(service.categories$);
+      const ids = categories.map((c) => c.id);
+      expect(ids[0]).toBe('favorites');
+      expect(ids.indexOf('apps')).toBeLessThan(ids.indexOf('media'));
+      expect(ids.indexOf('bookmarks')).toBeLessThan(ids.indexOf('media'));
+      expect(ids.indexOf('dev')).toBeLessThan(ids.indexOf('media'));
+    });
+  });
+
+  describe('selectedCategory$ fallback', () => {
+    it('should auto-select the first visible category when the current selection disappears', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: false,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      service.setSelectedCategory(FAVORITES_CATEGORY.id);
+
+      // Allow any async side effects to propagate
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Remove all favorites so Favorites category disappears
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: false,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: false,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const selectedId = await firstValueFrom(service.selectedCategory$);
+      expect(selectedId).toBe('media');
+    });
+
+    it('should select FAVORITES_CATEGORY as first visible when showAllCategory is false and favorites exist', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: true,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: false,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const selectedId = await firstValueFrom(service.selectedCategory$);
+      expect(selectedId).toBe(FAVORITES_CATEGORY.id);
+    });
+
+    it('should select the first user category when showAllCategory is false and no favorites exist', async () => {
+      configSubject.next(
+        createConfig({
+          applications: [
+            {
+              id: 'plex',
+              name: 'Plex',
+              description: '',
+              url: 'https://plex.example.com',
+              icon: {type: 'name', value: 'plex'},
+              category: 'media',
+              openNewTab: true,
+              tags: [],
+              favorite: false,
+            },
+          ],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: false,
+            allowBookmarks: false,
+          },
+          categories: [
+            {id: 'media', name: 'Media'},
+          ],
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const selectedId = await firstValueFrom(service.selectedCategory$);
+      expect(selectedId).toBe('media');
+    });
+  });
+});

--- a/src/app/core/services/category.service.ts
+++ b/src/app/core/services/category.service.ts
@@ -2,7 +2,7 @@ import {inject, Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 import {map} from 'rxjs/operators';
 
-import {APP_CATEGORY, BOOKMARKS_CATEGORY, Category} from '../models/dashboard.models';
+import {APP_CATEGORY, BOOKMARKS_CATEGORY, FAVORITES_CATEGORY, Category} from '../models/dashboard.models';
 
 import {ConfigService} from './config.service';
 
@@ -16,6 +16,10 @@ export class CategoryService {
     map((config) => {
       const categories: Category[] = [];
 
+      if (config.applications.some((app) => app.favorite)) {
+        categories.push(FAVORITES_CATEGORY);
+      }
+
       if (config.settings.showAllCategory) {
         categories.push(APP_CATEGORY);
       }
@@ -24,10 +28,22 @@ export class CategoryService {
         categories.push(BOOKMARKS_CATEGORY);
       }
 
-      return [...categories, ...config.categories].sort((a, b) => a.name.localeCompare(b.name));
+      return [
+        ...categories,
+        ...config.categories.sort((a, b) => a.name.localeCompare(b.name)),
+      ];
     }),
   );
   readonly selectedCategory$ = this.selectedCategorySubject.asObservable();
+
+  constructor() {
+    this.categories$.subscribe((categories) => {
+      const ids = categories.map((c) => c.id);
+      if (!ids.includes(this.selectedCategorySubject.value) && categories.length > 0) {
+        this.selectedCategorySubject.next(categories[0].id);
+      }
+    });
+  }
 
   /**
    * Update selected category

--- a/src/app/core/services/search.service.spec.ts
+++ b/src/app/core/services/search.service.spec.ts
@@ -1,0 +1,107 @@
+import {TestBed} from '@angular/core/testing';
+import {BehaviorSubject} from 'rxjs';
+
+import {SearchService} from './search.service';
+import {ConfigService} from './config.service';
+
+import {
+  APP_CATEGORY,
+  BOOKMARKS_CATEGORY,
+  FAVORITES_CATEGORY,
+  SelfhostedApp,
+} from '../models/dashboard.models';
+
+describe('SearchService', () => {
+  let service: SearchService;
+
+  const createApp = (overrides: Partial<SelfhostedApp> = {}): SelfhostedApp => ({
+    id: 'test',
+    name: 'Test App',
+    description: 'A test app',
+    url: 'https://test.example.com',
+    icon: {type: 'name', value: 'test'},
+    category: 'media',
+    openNewTab: true,
+    tags: [],
+    favorite: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SearchService,
+        {
+          provide: ConfigService,
+          useValue: {
+            config$: new BehaviorSubject({}),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(SearchService);
+  });
+
+  describe('filterApps', () => {
+    it('should return only favorited apps when categoryId is FAVORITES_CATEGORY.id', () => {
+      const apps: SelfhostedApp[] = [
+        createApp({id: 'plex', name: 'Plex', favorite: true}),
+        createApp({id: 'radarr', name: 'Radarr', favorite: false}),
+        createApp({id: 'sonarr', name: 'Sonarr', favorite: true}),
+      ];
+
+      const result = service.filterApps(apps, '', FAVORITES_CATEGORY.id, false);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((a) => a.id)).toEqual(['plex', 'sonarr']);
+    });
+
+    it('should return empty array when no favorites exist and FAVORITES_CATEGORY is selected', () => {
+      const apps: SelfhostedApp[] = [
+        createApp({id: 'radarr', name: 'Radarr', favorite: false}),
+        createApp({id: 'sonarr', name: 'Sonarr', favorite: false}),
+      ];
+
+      const result = service.filterApps(apps, '', FAVORITES_CATEGORY.id, false);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should bypass category filter when searchAll is true, returning matching apps regardless of favorite status', () => {
+      const apps: SelfhostedApp[] = [
+        createApp({id: 'plex', name: 'Plex Media', favorite: true}),
+        createApp({id: 'radarr', name: 'Radarr', favorite: false}),
+      ];
+
+      const result = service.filterApps(apps, 'Plex', FAVORITES_CATEGORY.id, true);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('plex');
+    });
+
+    it('should still include favorited apps in their original category', () => {
+      const apps: SelfhostedApp[] = [
+        createApp({id: 'plex', name: 'Plex', category: 'media', favorite: true}),
+        createApp({id: 'radarr', name: 'Radarr', category: 'media', favorite: false}),
+      ];
+
+      const result = service.filterApps(apps, '', 'media', false);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should combine favorites filter with search text', () => {
+      const apps: SelfhostedApp[] = [
+        createApp({id: 'plex', name: 'Plex', favorite: true}),
+        createApp({id: 'plex-2', name: 'Plex Two', favorite: true}),
+        createApp({id: 'radarr', name: 'Radarr', favorite: false}),
+      ];
+
+      const result = service.filterApps(apps, 'Two', FAVORITES_CATEGORY.id, false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('plex-2');
+    });
+  });
+});

--- a/src/app/core/services/search.service.ts
+++ b/src/app/core/services/search.service.ts
@@ -6,6 +6,7 @@ import {ConfigService} from './config.service';
 import {
   APP_CATEGORY,
   BOOKMARKS_CATEGORY,
+  FAVORITES_CATEGORY,
   DEFAULT_DASHBOARD_SEARCH_ENGINES,
   SearchEngine,
   SelfhostedApp
@@ -65,10 +66,13 @@ export class SearchService {
     if (searchAll) {
       filtered = apps;
     } else {
-      filtered =
-        categoryId === APP_CATEGORY.id
-          ? apps.filter(({ category }) => category !== BOOKMARKS_CATEGORY.id)
-          : apps.filter((app) => app.category === categoryId);
+      if (categoryId === APP_CATEGORY.id) {
+        filtered = apps.filter(({ category }) => category !== BOOKMARKS_CATEGORY.id);
+      } else if (categoryId === FAVORITES_CATEGORY.id) {
+        filtered = apps.filter((app) => app.favorite);
+      } else {
+        filtered = apps.filter((app) => app.category === categoryId);
+      }
     }
 
     if (!query.trim()) {

--- a/src/app/core/services/yaml-parser.service.spec.ts
+++ b/src/app/core/services/yaml-parser.service.spec.ts
@@ -1,0 +1,108 @@
+import {TestBed} from '@angular/core/testing';
+
+import {YamlParserService} from './yaml-parser.service';
+
+describe('YamlParserService', () => {
+  let service: YamlParserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [YamlParserService],
+    });
+
+    service = TestBed.inject(YamlParserService);
+  });
+
+  describe('parseYaml', () => {
+    it('should default favorite to false when not provided in YAML', () => {
+      const yamlWithoutFavorite = `
+metadata:
+  title: 'Test'
+  description: 'Test dashboard'
+
+categories:
+  - id: 'media'
+    name: 'Media'
+
+applications:
+  - id: 'plex'
+    name: 'Plex'
+    description: 'Media server'
+    url: 'https://plex.example.com'
+    icon:
+      type: 'name'
+      value: 'plex'
+    category: 'media'
+    openNewTab: true
+    tags:
+      - media
+
+bookmarks: []
+
+settings:
+  dateFormat: 'd MMMM yyyy'
+  datePosition: 'bottom'
+  showSeconds: false
+  showDate: true
+  itemsPerRow: 5
+  allowBookmarks: true
+  showAllCategory: true
+  showDescriptions: true
+  showLabels: true
+  searchEngines:
+    - 'google'
+`;
+
+      const result = service.parseYaml(yamlWithoutFavorite);
+
+      expect(result.success).toBe(true);
+      expect(result.data!.applications[0].favorite).toBe(false);
+    });
+
+    it('should parse favorite as true when provided in YAML', () => {
+      const yamlWithFavorite = `
+metadata:
+  title: 'Test'
+  description: 'Test dashboard'
+
+categories:
+  - id: 'media'
+    name: 'Media'
+
+applications:
+  - id: 'plex'
+    name: 'Plex'
+    description: 'Media server'
+    url: 'https://plex.example.com'
+    icon:
+      type: 'name'
+      value: 'plex'
+    category: 'media'
+    openNewTab: true
+    favorite: true
+    tags:
+      - media
+
+bookmarks: []
+
+settings:
+  dateFormat: 'd MMMM yyyy'
+  datePosition: 'bottom'
+  showSeconds: false
+  showDate: true
+  itemsPerRow: 5
+  allowBookmarks: true
+  showAllCategory: true
+  showDescriptions: true
+  showLabels: true
+  searchEngines:
+    - 'google'
+`;
+
+      const result = service.parseYaml(yamlWithFavorite);
+
+      expect(result.success).toBe(true);
+      expect(result.data!.applications[0].favorite).toBe(true);
+    });
+  });
+});

--- a/src/app/shared/components/app-card/app-card.component.spec.ts
+++ b/src/app/shared/components/app-card/app-card.component.spec.ts
@@ -28,6 +28,7 @@ describe('AppCardComponent', () => {
     category: 'media',
     openNewTab: true,
     tags: ['video', 'streaming'],
+    favorite: false,
   };
 
   const setup = async (

--- a/src/app/shared/components/app-categories/app-categories.component.spec.ts
+++ b/src/app/shared/components/app-categories/app-categories.component.spec.ts
@@ -8,7 +8,7 @@ import {AppService} from '../../../core/services/app.service';
 import {CategoryService} from '../../../core/services/category.service';
 import {SearchService} from '../../../core/services/search.service';
 
-import {APP_CATEGORY, Category} from '../../../core/models/dashboard.models';
+import {APP_CATEGORY, FAVORITES_CATEGORY, Category} from '../../../core/models/dashboard.models';
 
 describe('AppCategoriesComponent', () => {
   const categories: Category[] = [
@@ -125,5 +125,47 @@ describe('AppCategoriesComponent', () => {
     expect(appsButton).toHaveClass('bg-white/10', 'border-white/50');
     expect(mediaButton).toHaveAttribute('aria-pressed', 'false');
     expect(mediaButton).not.toHaveClass('bg-white/10', 'border-white/50');
+  });
+
+  it('should render FAVORITES_CATEGORY when present and maintain accessibility', async () => {
+    const categoriesWithFavorites: Category[] = [
+      FAVORITES_CATEGORY,
+      APP_CATEGORY,
+      {
+        id: 'media',
+        name: 'Media',
+      },
+    ];
+
+    selectedCategorySubject.next('favorites');
+
+    await render(AppCategoriesComponent, {
+      providers: [
+        {
+          provide: AppService,
+          useValue: appServiceMock,
+        },
+        {
+          provide: CategoryService,
+          useValue: {
+            categories$: of(categoriesWithFavorites),
+            selectedCategory$: selectedCategorySubject,
+          },
+        },
+        {
+          provide: SearchService,
+          useValue: {
+            haveSearchSubject,
+          },
+        },
+      ],
+    });
+
+    const favoritesButton = screen.getByRole('button', {name: 'Favorites'});
+
+    expect(favoritesButton).toBeInTheDocument();
+    expect(favoritesButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', {name: 'Apps'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Media'})).toBeInTheDocument();
   });
 });

--- a/src/app/views/dashboard/dashboard.component.spec.ts
+++ b/src/app/views/dashboard/dashboard.component.spec.ts
@@ -26,6 +26,7 @@ describe('DashboardComponent', () => {
     category: 'media',
     openNewTab: true,
     tags: ['video'],
+    favorite: false,
   };
 
   const settingsSubject = new BehaviorSubject<DashboardSettings>(DEFAULT_DASHBOARD_CONFIG.settings);
@@ -140,6 +141,7 @@ describe('DashboardComponent', () => {
       id: 'radarr',
       name: 'Radarr',
       url: 'https://radarr.example.com',
+      favorite: false,
     };
 
     await setup({


### PR DESCRIPTION
## Summary

Adds the ability to mark applications as **favorites** in the YAML configuration. Favorited apps are automatically grouped into a new virtual **\"Favorites\"** category that appears at the top of the category list.

## Changes

- **Schema**: Added `favorite: boolean` field to `SelfhostedAppSchema` with `.default(false)` — fully backward-compatible
- **Virtual Category**: New `FAVORITES_CATEGORY` constant; dynamically prepended when ≥1 app is favorited
- **Services updated**:
  - `CategoryService` — prepends Favorites, handles auto-selection/fallback
  - `AppService` — filters by Favorites category, bookmarks inherit `favorite: false`
  - `SearchService` — Favorites category filtering
- **Tests**: 16 new tests across 4 service spec files (CategoryService, AppService, SearchService, YamlParserService)
- **Docs**: Updated README Quick Start and Configuration Reference with `favorite` field

## How to use

In your `dashboard.yaml`, add `favorite: true` to any application:

```yaml
applications:
  - id: 'plex'
    name: 'Plex'
    ...
    favorite: true
```

The app will appear both in its original category and in the new **Favorites** category.

## Backward Compatibility

Omitting the `favorite` key behaves exactly like `favorite: false` thanks to Zod `.default(false)`. Existing configs work without any changes.

## Test Results

- **54 tests passing** (16 new)
- Build successful
- TypeScript strict mode clean