### PR TITLE
docs(changelog): add v1.0.0 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## v1.0.0
+
+### New Features
+
+- **Favorite Applications**: Added support for marking applications as favorites. Favorites are automatically grouped into a dedicated "Favorites" category and can be filtered via search.
+
+### Testing & Quality
+
+- **Component Test Suite**: Added comprehensive tests for `app-header`, `app-card`, `app-categories`, `app-finder`, and `dashboard` components.
+- **Service Test Coverage**: Added unit tests for `AppService`, `CategoryService`, `SearchService`, and `YamlParserService`.
+- **Keyboard Accessibility**: Added keyboard event handling and test coverage for `Space` and `Enter` activation on interactive elements.
+
+### CI / Tooling
+
+- **PR Test Workflow**: Added automated test execution for pull requests targeting `develop` and `main`.
+- **CODEOWNERS**: Added `CODEOWNERS` file requiring `rackandhost` approval for changes.
+
+### Changed Files
+
+- `src/app/core/models/dashboard.models.ts`
+- `src/app/core/services/app.service.ts`
+- `src/app/core/services/app.service.spec.ts`
+- `src/app/core/services/category.service.ts`
+- `src/app/core/services/category.service.spec.ts`
+- `src/app/core/services/search.service.ts`
+- `src/app/core/services/search.service.spec.ts`
+- `src/app/core/services/yaml-parser.service.spec.ts`
+- `src/app/shared/components/app-card/app-card.component.html`
+- `src/app/shared/components/app-card/app-card.component.ts`
+- `src/app/shared/components/app-card/app-card.component.spec.ts`
+- `src/app/shared/components/app-categories/app-categories.component.html`
+- `src/app/shared/components/app-categories/app-categories.component.ts`
+- `src/app/shared/components/app-categories/app-categories.component.spec.ts`
+- `src/app/shared/components/app-finder/app-finder.component.html`
+- `src/app/shared/components/app-finder/app-finder.component.spec.ts`
+- `src/app/shared/components/app-header/app-header.component.spec.ts`
+- `src/app/views/dashboard/dashboard.component.spec.ts`
+- `README.md`
+- `package.json`
+- `package-lock.json`
+- `.github/workflows/test.yml`
+- `CODEOWNERS`
+
+### Summary
+
+This release marks the v1.0.0 stable release, removing beta references. It introduces favorite application support, significantly expands test coverage across components and services, and adds CI automation for pull requests.
+
 ## v0.2.0
 
 ### Bug Fixes & Improvements


### PR DESCRIPTION
## Summary
- Adds the missing v1.0.0 release entry to `CHANGELOG.md`
- Documents the favorites feature, expanded test coverage, and CI/tooling changes included in the v1.0.0 release

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | Added full v1.0.0 release section with features, tests, CI, file list, and summary |

## Test Plan
- [x] Verified all commits between v0.2.0 and v1.0.0 are covered
- [x] File list matches actual changed files in the release