### PR TITLE
fix(ui): prevent background image from shifting on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Pending Release]
+
+### Bug Fixes
+
+- **Mobile Background**: Fixed background image shifting when navigating between categories on mobile devices. The background is now rendered on a fixed-position layer independent of content height.
+
+### Changed Files
+
+- `src/index.html`
+- `src/styles.css`
+- `src/app/views/dashboard/dashboard.component.ts`
+- `src/app/views/dashboard/dashboard.component.spec.ts`
+
 ## v1.0.0
 
 ### New Features

--- a/src/app/views/dashboard/dashboard.component.spec.ts
+++ b/src/app/views/dashboard/dashboard.component.spec.ts
@@ -47,9 +47,11 @@ describe('DashboardComponent', () => {
 
   const expectBackgroundImageToBe = (expectedUrl: string) => {
     const escapedUrl = expectedUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const bgLayer = document.getElementById('app-background');
 
-    expect(document.body.style.backgroundImage).toMatch(new RegExp(`^url\\(["']?${escapedUrl}["']?\\)$`));
-    expect(document.body.style.backgroundImage.match(/url\(/g)).toHaveLength(1);
+    expect(bgLayer).not.toBeNull();
+    expect(bgLayer!.style.backgroundImage).toMatch(new RegExp(`^url\\(["']?${escapedUrl}["']?\\)$`));
+    expect(bgLayer!.style.backgroundImage.match(/url\(/g)).toHaveLength(1);
   };
 
   const setup = async ({
@@ -63,7 +65,13 @@ describe('DashboardComponent', () => {
     settings?: DashboardSettings;
     isDarkMode?: boolean;
   } = {}): Promise<void> => {
-    document.body.style.backgroundImage = '';
+    let bgLayer = document.getElementById('app-background');
+    if (!bgLayer) {
+      bgLayer = document.createElement('div');
+      bgLayer.id = 'app-background';
+      document.body.appendChild(bgLayer);
+    }
+    bgLayer.style.backgroundImage = '';
     appServiceMock.setSearchQuery.mockReset();
     appServiceMock.setSelectedCategory.mockReset();
     iconServiceMock.getIconUrl.mockClear();
@@ -227,7 +235,7 @@ describe('DashboardComponent', () => {
     });
 
     expectBackgroundImageToBe('https://cdn.example.com/dark.jpg');
-    expect(document.body.style.backgroundImage).not.toContain('/img/https://cdn.example.com/dark.jpg');
+    expect(document.getElementById('app-background')!.style.backgroundImage).not.toContain('/img/https://cdn.example.com/dark.jpg');
   });
 
   it('should not prefix http background image URLs with /img/', async () => {
@@ -242,7 +250,7 @@ describe('DashboardComponent', () => {
     });
 
     expectBackgroundImageToBe('http://cdn.example.com/light.jpg');
-    expect(document.body.style.backgroundImage).not.toContain('/img/http://cdn.example.com/light.jpg');
+    expect(document.getElementById('app-background')!.style.backgroundImage).not.toContain('/img/http://cdn.example.com/light.jpg');
   });
 
   it('should update the background image when the theme changes after render', async () => {

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -70,13 +70,14 @@ export class DashboardComponent implements OnDestroy {
   private setBackgroundImage(
     { lightBackgroundImage, darkBackgroundImage }: { lightBackgroundImage: string, darkBackgroundImage: string }
   ): void {
-    const body$ = document.getElementsByTagName('body')[0];
+    const bgLayer = document.getElementById('app-background');
+    if (!bgLayer) return;
 
     const selectedImage: string = this.themeService.isDarkMode() ? darkBackgroundImage : lightBackgroundImage;
 
     const isImageAnUrl = selectedImage.startsWith('https') || selectedImage.startsWith('http');
 
-    body$.style.backgroundImage = `url(${isImageAnUrl ? '' : '/img/' }${selectedImage})`;
+    bgLayer.style.backgroundImage = `url(${isImageAnUrl ? '' : '/img/' }${selectedImage})`;
   }
 
   ngOnDestroy(): void {

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/x-icon" href="img/mando.png">
 </head>
 <body>
+  <div id="app-background"></div>
   <app-root></app-root>
 </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,18 +54,27 @@
 /* Body styles */
 body {
   min-height: 100vh;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 100% 100%;
   color: rgb(255 255 255);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   position: relative;
 }
 
+#app-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -2;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
 body:after {
   content: '';
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
## Summary
- Fixes the background image shifting/moving when navigating between categories with different numbers of apps on mobile devices.
- Moves the background from the `body` element to a dedicated fixed-position `#app-background` layer that is always viewport-relative.

## Changes
| File | Change |
|------|--------|
| `src/index.html` | Added `<div id="app-background">` before `<app-root>` |
| `src/styles.css` | Added `#app-background` fixed styles; removed `background-*` from `body`; changed `body:after` to `position: fixed` |
| `src/app/views/dashboard/dashboard.component.ts` | Updated `setBackgroundImage()` to target `#app-background` instead of `document.body` |
| `src/app/views/dashboard/dashboard.component.spec.ts` | Updated test assertions to check `#app-background` element |

## Test Plan
- [x] All 54 tests pass
- [x] Background image tests updated and passing for theme changes, settings changes, and URL handling

Closes #17