### PR TITLE
docs(changelog): add [Pending Release] section for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Pending Release]
+
+### Bug Fixes
+
+- **Mobile Background**: Fixed background image shifting when navigating between categories on mobile devices. The background is now rendered on a fixed-position layer independent of content height.
+
+### Changed Files
+
+- `src/index.html`
+- `src/styles.css`
+- `src/app/views/dashboard/dashboard.component.ts`
+- `src/app/views/dashboard/dashboard.component.spec.ts`
+
 ## v1.0.0
 
 ### New Features


### PR DESCRIPTION
## Summary
- Adds a `[Pending Release]` section at the top of `CHANGELOG.md` to accumulate unreleased changes.
- When a new version is released, this section only needs to be renamed to the version number.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | Added `[Pending Release]` section with the mobile background fix from #17 |

## Test Plan
- [x] Markdown renders correctly
- [x] Section structure follows existing changelog format