### PR TITLE
docs(changelog): add unreleased entry for release notes template fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### CI / Tooling
+
+- **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
+
 ## v1.0.1
 
 ### Bug Fixes


### PR DESCRIPTION
Related to #27, #28

## Summary
- Adds an `Unreleased` section to `CHANGELOG.md` documenting the fix applied in PR #28.
- This ensures the release notes template fix is not forgotten when the next release is cut.

## Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Added `## Unreleased` section with CI/Tooling entry for the release notes template fix |

## Test Plan
- [x] Verified CHANGELOG.md renders correctly
- [x] Entry accurately describes the bug and fix from #28

## Contributor Checklist
- [x] Linked related issues (#27, #28)
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers