### PR TITLE
fix: keep header and finder fixed while apps area scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
+
 ### CI / Tooling
 
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -1,14 +1,17 @@
-<main class="pb-14">
-  <app-header />
+<main class="flex flex-col h-screen overflow-hidden">
+  <app-header class="shrink-0" />
 
-  <div class="p-6 md:p-8 md:pt-0 flex flex-col justify-center">
+  <div class="shrink-0 p-6 md:p-8 md:pt-0 flex flex-col justify-center">
     <app-clock />
 
     <app-finder />
 
     <app-categories class="flex items-center justify-center" />
+  </div>
 
-    <!-- Apps grid -->
+  <!-- Apps grid - scrollable -->
+  <div class="flex-1 overflow-y-auto px-6 md:px-8 pb-14">
+
     @if (filteredApps$ | async; as apps) {
       @if (apps.length > 0) {
         <section
@@ -41,5 +44,5 @@
     }
   </div>
 
-  <app-footer />
+  <app-footer class="shrink-0" />
 </main>


### PR DESCRIPTION
## What
Layout change: header, finder, and categories are now sticky while only the apps area scrolls.

## Why
When a user has many apps, the header and finder were hidden when scrolling. Now they stay visible for easy access.

## How
-  uses 
- Header, finder section, and footer use  to stay fixed
- Apps container uses  to scroll independently

Closes rackandhost/getmando#30