### PR TITLE
ci(node): pin test workflow to Node 22 LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 ### CI / Tooling
 
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
+- **Node 22 LTS CI Runtime**: Pinned the GitHub Actions Node.js test workflow to Node 22 LTS and documented Node 22 LTS in the README as the recommended local version because it matches CI.
+
+### Changed Files
+
+- `.github/workflows/test.yml`
+- `README.md`
+- `CHANGELOG.md`
 
 ## v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -488,8 +488,10 @@ settings:
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 22 LTS (recommended; matches the version used in CI)
 - npm 11+
+
+GitHub Actions CI runs on Node.js 22 LTS, and using the same version locally is recommended.
 
 ### Setup
 


### PR DESCRIPTION
Closes #34

## Summary
- pin the PR test workflow to Node.js 22 LTS instead of Node 24
- document Node.js 22 LTS as the recommended local version because it matches CI
- update the changelog for the unreleased CI/tooling change

## Changes
| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Changed the GitHub Actions Node runtime from 24 to 22 |
| `README.md` | Documented Node.js 22 LTS as the recommended local version because it matches CI |
| `CHANGELOG.md` | Added an unreleased CI / Tooling entry and changed files |

## Test Plan
- [x] Audited `.github/workflows/` for Node version references
- [x] Verified `.github/workflows/test.yml` now uses `node-version: 22`
- [x] Verified README and CHANGELOG wording matches the actual scope
- [x] No shell scripts changed, so shellcheck is not applicable

## Follow-up
- Focused-test CI guard tracked separately in #42

## Checklist
- [x] Linked an approved issue
- [x] Updated documentation/changelog for the behavior change
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` trailers added