### PR TITLE
fix(logging): centralize production-safe logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
+- **Production Logging Cleanup**: Replaced development-only `console.log` usage in dashboard initialization and config loading flows with a centralized logger service, while removing the dashboard click debug log from production code.
 
 ### CI / Tooling
 
@@ -16,6 +17,12 @@
 - `.github/workflows/test.yml`
 - `README.md`
 - `CHANGELOG.md`
+- `src/app/core/initializers/dashboard.initializer.ts`
+- `src/app/core/services/app.service.ts`
+- `src/app/core/services/logger.service.ts`
+- `src/app/core/services/logger.service.spec.ts`
+- `src/app/core/services/yaml-loader.service.ts`
+- `src/app/views/dashboard/dashboard.component.ts`
 
 ## v1.0.1
 

--- a/src/app/core/initializers/dashboard.initializer.spec.ts
+++ b/src/app/core/initializers/dashboard.initializer.spec.ts
@@ -1,0 +1,69 @@
+import {TestBed} from '@angular/core/testing';
+import {of, throwError} from 'rxjs';
+
+import {initializeDashboard} from './dashboard.initializer';
+import {YamlLoaderService} from '../services/yaml-loader.service';
+import {AppService} from '../services/app.service';
+import {LoggerService} from '../services/logger.service';
+import {DEFAULT_DASHBOARD_CONFIG} from '../models/dashboard.models';
+
+describe('initializeDashboard', () => {
+  let logger: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  let yamlLoader: {
+    loadDashboardConfig: ReturnType<typeof vi.fn>;
+  };
+  let appService: {
+    initializeConfig: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    yamlLoader = {
+      loadDashboardConfig: vi.fn(),
+    };
+    appService = {
+      initializeConfig: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: LoggerService, useValue: logger }],
+    });
+  });
+
+  it('should initialize config and log success when the dashboard loads', async () => {
+    yamlLoader.loadDashboardConfig.mockReturnValue(of(DEFAULT_DASHBOARD_CONFIG));
+
+    const initializer = TestBed.runInInjectionContext(() =>
+      initializeDashboard(yamlLoader as unknown as YamlLoaderService, appService as unknown as AppService),
+    );
+
+    await initializer();
+
+    expect(logger.debug).toHaveBeenCalledWith('[AppInitializer] Starting dashboard initialization...');
+    expect(appService.initializeConfig).toHaveBeenCalledWith(DEFAULT_DASHBOARD_CONFIG);
+    expect(logger.info).toHaveBeenCalledWith('[AppInitializer] Dashboard initialized successfully');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should log and rethrow when dashboard initialization fails', async () => {
+    const initError = new Error('load failed');
+    yamlLoader.loadDashboardConfig.mockReturnValue(throwError(() => initError));
+
+    const initializer = TestBed.runInInjectionContext(() =>
+      initializeDashboard(yamlLoader as unknown as YamlLoaderService, appService as unknown as AppService),
+    );
+
+    await expect(initializer()).rejects.toThrow(initError);
+
+    expect(appService.initializeConfig).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith('[AppInitializer] Failed to initialize dashboard:', initError);
+  });
+});

--- a/src/app/core/initializers/dashboard.initializer.ts
+++ b/src/app/core/initializers/dashboard.initializer.ts
@@ -1,8 +1,9 @@
-import {Provider} from '@angular/core';
+import {inject, Provider} from '@angular/core';
 import {firstValueFrom} from 'rxjs';
 
 import {YamlLoaderService} from '../services/yaml-loader.service';
 import {AppService} from '../services/app.service';
+import {LoggerService} from '../services/logger.service';
 
 /**
  * Factory function to initialize dashboard configuration
@@ -14,16 +15,18 @@ export function initializeDashboard(
   yamlLoader: YamlLoaderService,
   appService: AppService,
 ): () => Promise<void> {
+  const logger = inject(LoggerService);
+
   return async () => {
-    console.log('[AppInitializer] Starting dashboard initialization...');
+    logger.debug('[AppInitializer] Starting dashboard initialization...');
 
     return firstValueFrom(yamlLoader.loadDashboardConfig())
       .then((config) => {
         appService.initializeConfig(config);
-        console.log('[AppInitializer] Dashboard initialized successfully');
+        logger.info('[AppInitializer] Dashboard initialized successfully');
       })
       .catch((error) => {
-        console.error('[AppInitializer] Failed to initialize dashboard:', error);
+        logger.error('[AppInitializer] Failed to initialize dashboard:', error);
         throw error;
       });
   };

--- a/src/app/core/services/app.service.ts
+++ b/src/app/core/services/app.service.ts
@@ -17,6 +17,7 @@ import {ConfigService} from './config.service';
 import {SearchService} from './search.service';
 import {CategoryService} from './category.service';
 import {BookmarkService} from './bookmark.service';
+import {LoggerService} from './logger.service';
 
 /**
  * Service for managing dashboard application state
@@ -29,6 +30,7 @@ export class AppService {
   private searchService = inject(SearchService);
   private categoryService = inject(CategoryService);
   private bookmarkService = inject(BookmarkService);
+  private logger = inject(LoggerService);
 
   appVersion = version;
 
@@ -79,7 +81,7 @@ export class AppService {
    */
   initializeConfig(config: DashboardConfig): void {
     this.configService.subject.next(config);
-    console.log('[AppService] Dashboard config initialized');
+    this.logger.info('[AppService] Dashboard config initialized');
   }
 
   /**

--- a/src/app/core/services/logger.service.spec.ts
+++ b/src/app/core/services/logger.service.spec.ts
@@ -1,0 +1,57 @@
+import {LoggerService} from './logger.service';
+
+describe('LoggerService', () => {
+  let service: LoggerService;
+
+  const setDevMode = (value: boolean): void => {
+    Reflect.set(globalThis as Record<string, unknown>, 'ngDevMode', value);
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setDevMode(true);
+    service = new LoggerService();
+  });
+
+  it('should log debug messages only in dev mode', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+
+    setDevMode(true);
+    service.debug('visible');
+    setDevMode(false);
+    service.debug('hidden');
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith('visible');
+  });
+
+  it('should log info messages only in dev mode', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    setDevMode(true);
+    service.info('visible');
+    setDevMode(false);
+    service.info('hidden');
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith('visible');
+  });
+
+  it('should always log warning messages', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    service.warn('warning');
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith('warning');
+  });
+
+  it('should always log error messages', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    service.error('error');
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledWith('error');
+  });
+});

--- a/src/app/core/services/logger.service.ts
+++ b/src/app/core/services/logger.service.ts
@@ -1,0 +1,24 @@
+import {Injectable, isDevMode} from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class LoggerService {
+  debug(message?: unknown, ...optionalParams: unknown[]): void {
+    if (!isDevMode()) return;
+
+    console.debug(message, ...optionalParams);
+  }
+
+  info(message?: unknown, ...optionalParams: unknown[]): void {
+    if (!isDevMode()) return;
+
+    console.info(message, ...optionalParams);
+  }
+
+  warn(message?: unknown, ...optionalParams: unknown[]): void {
+    console.warn(message, ...optionalParams);
+  }
+
+  error(message?: unknown, ...optionalParams: unknown[]): void {
+    console.error(message, ...optionalParams);
+  }
+}

--- a/src/app/core/services/yaml-loader.service.spec.ts
+++ b/src/app/core/services/yaml-loader.service.spec.ts
@@ -1,0 +1,97 @@
+import {TestBed} from '@angular/core/testing';
+import {HttpClient} from '@angular/common/http';
+import {firstValueFrom, of, throwError} from 'rxjs';
+
+import {YamlLoaderService} from './yaml-loader.service';
+import {YamlParserService} from './yaml-parser.service';
+import {LoggerService} from './logger.service';
+
+import {DEFAULT_DASHBOARD_CONFIG} from '../models/dashboard.models';
+
+describe('YamlLoaderService', () => {
+  let service: YamlLoaderService;
+  let httpClient: { get: ReturnType<typeof vi.fn>; head: ReturnType<typeof vi.fn> };
+  let yamlParser: {
+    parseYamlOrThrow: ReturnType<typeof vi.fn>;
+    getDefaultConfig: ReturnType<typeof vi.fn>;
+  };
+  let logger: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    httpClient = {
+      get: vi.fn(),
+      head: vi.fn(),
+    };
+    yamlParser = {
+      parseYamlOrThrow: vi.fn(),
+      getDefaultConfig: vi.fn(() => DEFAULT_DASHBOARD_CONFIG),
+    };
+    logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        YamlLoaderService,
+        { provide: HttpClient, useValue: httpClient },
+        { provide: YamlParserService, useValue: yamlParser },
+        { provide: LoggerService, useValue: logger },
+      ],
+    });
+
+    service = TestBed.inject(YamlLoaderService);
+  });
+
+  it('should log debug and info on successful config load', async () => {
+    const config = {
+      ...DEFAULT_DASHBOARD_CONFIG,
+      applications: [
+        {
+          id: 'plex',
+          name: 'Plex',
+          description: 'Media server',
+          url: 'https://plex.example.com',
+          icon: { type: 'name', value: 'plex' },
+          category: 'apps',
+          openNewTab: true,
+          tags: [],
+          favorite: false,
+        },
+      ],
+    };
+
+    httpClient.get.mockReturnValue(of('yaml-content'));
+    yamlParser.parseYamlOrThrow.mockReturnValue(config);
+
+    await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(config);
+
+    expect(logger.debug).toHaveBeenCalledWith('[YamlLoader] YAML content loaded successfully');
+    expect(logger.info).toHaveBeenCalledWith('[YamlLoader] Dashboard config loaded:', {
+      title: config.metadata.title,
+      apps: config.applications.length,
+      categories: config.categories.length,
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should log error and warn before falling back to default config', async () => {
+    const loadError = new Error('missing dashboard.yaml');
+
+    httpClient.get.mockReturnValue(throwError(() => loadError));
+
+    await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(DEFAULT_DASHBOARD_CONFIG);
+
+    expect(logger.error).toHaveBeenCalledWith('[YamlLoader] Failed to load dashboard config:', loadError);
+    expect(logger.warn).toHaveBeenCalledWith('[YamlLoader] Falling back to default configuration');
+    expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/core/services/yaml-loader.service.ts
+++ b/src/app/core/services/yaml-loader.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@angular/common/http';
 import {catchError, map, Observable, of, tap} from 'rxjs';
 
 import {YamlParserService} from './yaml-parser.service';
+import {LoggerService} from './logger.service';
 
 import {DashboardConfig} from '../models/dashboard.models';
 
@@ -14,6 +15,7 @@ import {DashboardConfig} from '../models/dashboard.models';
 export class YamlLoaderService {
   private readonly http = inject(HttpClient);
   private readonly yamlParser = inject(YamlParserService);
+  private readonly logger = inject(LoggerService);
 
   private readonly CONFIG_PATH = '/config/dashboard.yaml';
 
@@ -24,13 +26,13 @@ export class YamlLoaderService {
   loadDashboardConfig(): Observable<DashboardConfig> {
     return this.http.get(this.CONFIG_PATH, { responseType: 'text' }).pipe(
       tap(() => {
-        console.log('[YamlLoader] YAML content loaded successfully');
+        this.logger.debug('[YamlLoader] YAML content loaded successfully');
       }),
       // Parse and validate YAML
       map((yamlContent: string) => this.yamlParser.parseYamlOrThrow(yamlContent)),
       // Log success
       tap((config: DashboardConfig) => {
-        console.log('[YamlLoader] Dashboard config loaded:', {
+        this.logger.info('[YamlLoader] Dashboard config loaded:', {
           title: config.metadata.title,
           apps: config.applications.length,
           categories: config.categories.length
@@ -38,8 +40,8 @@ export class YamlLoaderService {
       }),
       // Handle errors gracefully
       catchError((error) => {
-        console.error('[YamlLoader] Failed to load dashboard config:', error);
-        console.log('[YamlLoader] Falling back to default configuration');
+        this.logger.error('[YamlLoader] Failed to load dashboard config:', error);
+        this.logger.warn('[YamlLoader] Falling back to default configuration');
         return of(this.yamlParser.getDefaultConfig());
       }),
     );
@@ -52,7 +54,7 @@ export class YamlLoaderService {
   loadDashboardConfigWithFallback(): Observable<DashboardConfig> {
     return this.loadDashboardConfig().pipe(
       catchError((error) => {
-        console.error('[YamlLoader] All attempts failed, using default config:', error);
+        this.logger.error('[YamlLoader] All attempts failed, using default config:', error);
         return of(this.yamlParser.getDefaultConfig());
       }),
     );

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -63,9 +63,7 @@ export class DashboardComponent implements OnDestroy {
   /**
    * Handle app click (for tracking/analytics if needed)
    */
-  onAppClick(app: unknown): void {
-    console.log('[Dashboard] App clicked:', app);
-  }
+  onAppClick(_app: unknown): void {}
 
   private setBackgroundImage(
     { lightBackgroundImage, darkBackgroundImage }: { lightBackgroundImage: string, darkBackgroundImage: string }


### PR DESCRIPTION
Closes #30

## Summary
- add a centralized LoggerService that suppresses debug and info logs outside development mode
- replace production-facing debug console usage in dashboard initialization and YAML loading flows
- add logger-focused tests and update the changelog for the unreleased fix

## Changes
| File | Change |
|------|--------|
| `src/app/core/services/logger.service.ts` | Added a centralized logger with dev-only debug and info methods |
| `src/app/core/services/logger.service.spec.ts` | Added tests for dev-only and always-on logging behavior |
| `src/app/core/initializers/dashboard.initializer.ts` | Routed initializer logs through LoggerService |
| `src/app/core/initializers/dashboard.initializer.spec.ts` | Added behavior tests for initializer success and failure logging |
| `src/app/core/services/app.service.ts` | Routed config initialization logs through LoggerService |
| `src/app/core/services/yaml-loader.service.ts` | Routed YAML loading logs through LoggerService and kept warn/error fallback logging |
| `src/app/core/services/yaml-loader.service.spec.ts` | Added behavior tests for YAML loader success and fallback logging |
| `src/app/views/dashboard/dashboard.component.ts` | Removed the no-value dashboard click debug log |
| `CHANGELOG.md` | Added an unreleased bug-fix entry and changed files |

## Test Plan
- [x] `npx ng test --watch=false --include="src/app/core/services/logger.service.spec.ts" --include="src/app/core/services/yaml-loader.service.spec.ts" --include="src/app/core/initializers/dashboard.initializer.spec.ts"`
- [x] `npm run build`
- [x] Verified there are no remaining unguarded `console.log` calls in `src/`
- [x] No shell scripts changed, so shellcheck is not applicable

## Follow-up
- Focused-test CI guard remains tracked separately in #42
- `src/main.ts` bootstrap `console.error` remains intentionally unchanged because it is outside issue #30 scope

## Checklist
- [x] Linked an approved issue
- [x] Updated documentation/changelog for the behavior change
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` trailers added