### PR TITLE
ci(test): fail CI on focused tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check focused tests
+        run: npm run check:focused-tests
+
       - name: Run tests
         run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,18 @@
 
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
 - **Node 22 LTS CI Runtime**: Pinned the GitHub Actions Node.js test workflow to Node 22 LTS and documented Node 22 LTS in the README as the recommended local version because it matches CI.
+- **Focused Test CI Guard**: Added a repository-level guard that fails pull request CI when committed focused tests such as `.only`, `fit`, `fdescribe`, or `.only.each(...)` are present, with regression coverage for the checker and its CLI contract.
 
 ### Changed Files
 
 - `.github/workflows/test.yml`
 - `README.md`
 - `CHANGELOG.md`
+- `package.json`
+- `scripts/check-focused-tests.mjs`
+- `scripts/check-focused-tests.test.mjs`
+- `src/testing/check-focused-tests-cli.spec.ts`
+- `src/testing/node-test-harness.d.ts`
 - `src/app/core/initializers/dashboard.initializer.ts`
 - `src/app/core/services/app.service.ts`
 - `src/app/core/services/logger.service.ts`

--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Contributions are welcome! Please feel free to submit issues or pull requests.
 - Follow Angular best practices
 - Use TypeScript strict mode
 - Write tests for new features
+- Do not commit focused tests such as `.only`, `fit`, or `fdescribe`; CI fails fast on them
 - Ensure accessibility (WCAG AA)
 - Keep components small and focused
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "pretest": "npm run test:focused-tests",
+    "test": "ng test",
+    "check:focused-tests": "node scripts/check-focused-tests.mjs",
+    "test:focused-tests": "vitest run scripts/check-focused-tests.test.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/scripts/check-focused-tests.mjs
+++ b/scripts/check-focused-tests.mjs
@@ -3,7 +3,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const FOCUSED_TEST_PATTERNS = [
-  { label: '.only', regex: /\b(?:describe|it|test|suite|context|specify)\s*\.\s*only\s*\(/g },
+  {
+    label: '.only',
+    regex:
+      /\b(?:describe|it|test|suite|context|specify)\b(?:\s*\.\s*[A-Za-z_$][\w$]*)*\s*\.\s*only\b(?:\s*\(|\s*\.\s*each\s*\()/g,
+  },
   { label: 'fit', regex: /\bfit\s*\(/g },
   { label: 'fdescribe', regex: /\bfdescribe\s*\(/g },
 ];

--- a/scripts/check-focused-tests.mjs
+++ b/scripts/check-focused-tests.mjs
@@ -1,0 +1,174 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FOCUSED_TEST_PATTERNS = [
+  { label: '.only', regex: /\b(?:describe|it|test|suite|context|specify)\s*\.\s*only\s*\(/g },
+  { label: 'fit', regex: /\bfit\s*\(/g },
+  { label: 'fdescribe', regex: /\bfdescribe\s*\(/g },
+];
+
+const IGNORED_DIRECTORIES = new Set(['.angular', '.git', 'dist', 'node_modules']);
+
+export function isTestFilePath(filePath) {
+  return /(?:^|\/)[^/]+\.(?:spec|test)\.(?:[cm]?[jt]sx?)$/u.test(filePath);
+}
+
+function sanitizeContentForPatternMatch(content) {
+  let result = '';
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let inTemplateLiteral = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const current = content[index];
+    const next = content[index + 1];
+    const previous = content[index - 1];
+
+    if (inLineComment) {
+      result += current === '\n' ? '\n' : ' ';
+
+      if (current === '\n') {
+        inLineComment = false;
+      }
+
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (current === '*' && next === '/') {
+        result += '  ';
+        inBlockComment = false;
+        index += 1;
+        continue;
+      }
+
+      result += current === '\n' ? '\n' : ' ';
+      continue;
+    }
+
+    if (!inDoubleQuote && !inTemplateLiteral && current === "'" && previous !== '\\') {
+      inSingleQuote = !inSingleQuote;
+      result += ' ';
+      continue;
+    }
+
+    if (!inSingleQuote && !inTemplateLiteral && current === '"' && previous !== '\\') {
+      inDoubleQuote = !inDoubleQuote;
+      result += ' ';
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote && current === '`' && previous !== '\\') {
+      inTemplateLiteral = !inTemplateLiteral;
+      result += ' ';
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote && !inTemplateLiteral && current === '/' && next === '/') {
+      result += '  ';
+      inLineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote && !inTemplateLiteral && current === '/' && next === '*') {
+      result += '  ';
+      inBlockComment = true;
+      index += 1;
+      continue;
+    }
+
+    result += inSingleQuote || inDoubleQuote || inTemplateLiteral ? ' ' : current;
+  }
+
+  return result;
+}
+
+function lineNumberFromIndex(content, index) {
+  return content.slice(0, index + 1).split('\n').length;
+}
+
+export function collectFocusedTestViolations(files) {
+  return files.flatMap(({ path: filePath, content }) => {
+    if (!isTestFilePath(filePath)) {
+      return [];
+    }
+
+    const searchableContent = sanitizeContentForPatternMatch(content);
+
+    return FOCUSED_TEST_PATTERNS.flatMap(({ label, regex }) =>
+      Array.from(searchableContent.matchAll(regex), (match) => {
+        const matchText = match[0] ?? '';
+        const lineAnchorOffset = label === '.only' ? matchText.indexOf('.only') : 0;
+
+        return {
+          filePath,
+          line: lineNumberFromIndex(searchableContent, (match.index ?? 0) + lineAnchorOffset),
+          pattern: label,
+        };
+      }),
+    ).sort((left, right) => left.line - right.line);
+  });
+}
+
+async function collectTestFiles(rootDir, currentDir = rootDir) {
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+
+      files.push(...(await collectTestFiles(rootDir, path.join(currentDir, entry.name))));
+      continue;
+    }
+
+    const absolutePath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, absolutePath);
+
+    if (!isTestFilePath(relativePath)) {
+      continue;
+    }
+
+    files.push({
+      path: relativePath,
+      content: await readFile(absolutePath, 'utf8'),
+    });
+  }
+
+  return files;
+}
+
+export async function checkFocusedTests(rootDir) {
+  const files = await collectTestFiles(rootDir);
+
+  return collectFocusedTestViolations(files);
+}
+
+async function main() {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const repositoryRoot = path.resolve(scriptDirectory, '..');
+  const violations = await checkFocusedTests(repositoryRoot);
+
+  if (violations.length === 0) {
+    console.log('Focused test check passed.');
+    return;
+  }
+
+  console.error('Focused test check failed. Remove committed focused tests:');
+
+  for (const violation of violations) {
+    console.error(`- ${violation.filePath}:${violation.line} (${violation.pattern})`);
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/check-focused-tests.test.mjs
+++ b/scripts/check-focused-tests.test.mjs
@@ -66,6 +66,62 @@ describe('collectFocusedTestViolations', () => {
     ]);
   });
 
+  it('detects focused .only chains before .each callbacks execute', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: [
+          "test.only.each([[1]])('row %s', () => {});",
+          "describe.only.each([[2]])('group %s', () => {});",
+        ].join('\n'),
+      },
+    ]);
+
+    expect(violations).toEqual([
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 1,
+        pattern: '.only',
+      },
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 2,
+        pattern: '.only',
+      },
+    ]);
+  });
+
+  it('detects chained Vitest focus APIs where .only follows another segment', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: [
+          "test.concurrent.only('component', () => {});",
+          "describe.concurrent.only('suite', () => {});",
+          "it.sequential.only('case', () => {});",
+        ].join('\n'),
+      },
+    ]);
+
+    expect(violations).toEqual([
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 1,
+        pattern: '.only',
+      },
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 2,
+        pattern: '.only',
+      },
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 3,
+        pattern: '.only',
+      },
+    ]);
+  });
+
   it('ignores normal tests, comments, and non-test files', () => {
     const violations = collectFocusedTestViolations([
       {

--- a/scripts/check-focused-tests.test.mjs
+++ b/scripts/check-focused-tests.test.mjs
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectFocusedTestViolations,
+  isTestFilePath,
+} from './check-focused-tests.mjs';
+
+describe('isTestFilePath', () => {
+  it('matches common repository test file names', () => {
+    expect(isTestFilePath('src/app/app.component.spec.ts')).toBe(true);
+    expect(isTestFilePath('scripts/check-focused-tests.test.mjs')).toBe(true);
+  });
+
+  it('ignores non-test files', () => {
+    expect(isTestFilePath('README.md')).toBe(false);
+    expect(isTestFilePath('src/app/app.component.ts')).toBe(false);
+  });
+});
+
+describe('collectFocusedTestViolations', () => {
+  it('detects .only, fit, and fdescribe usage in test files', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: [
+          "describe.only('component', () => {});",
+          "fit('runs one spec', () => {});",
+          "fdescribe('suite', () => {});",
+        ].join('\n'),
+      },
+    ]);
+
+    expect(violations).toEqual([
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 1,
+        pattern: '.only',
+      },
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 2,
+        pattern: 'fit',
+      },
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 3,
+        pattern: 'fdescribe',
+      },
+    ]);
+  });
+
+  it('detects newline-separated .only usage and reports the .only line', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: ["describe", "  .only('component', () => {});"] .join('\n'),
+      },
+    ]);
+
+    expect(violations).toEqual([
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 2,
+        pattern: '.only',
+      },
+    ]);
+  });
+
+  it('ignores normal tests, comments, and non-test files', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: [
+          "describe('component', () => {});",
+          "it('runs one spec', () => {});",
+          "// describe.only('commented', () => {});",
+          "/* fit('commented block', () => {}); */",
+          'const example = "describe.only(local only)";',
+        ].join('\n'),
+      },
+      {
+        path: 'README.md',
+        content: "Use describe.only locally when debugging.",
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it('preserves line numbers after multiline block comments', () => {
+    const violations = collectFocusedTestViolations([
+      {
+        path: 'src/app/example.component.spec.ts',
+        content: [
+          '/*',
+          "describe.only('commented', () => {});",
+          '*/',
+          '',
+          "fit('runs one spec', () => {});",
+        ].join('\n'),
+      },
+    ]);
+
+    expect(violations).toEqual([
+      {
+        filePath: 'src/app/example.component.spec.ts',
+        line: 5,
+        pattern: 'fit',
+      },
+    ]);
+  });
+});

--- a/src/testing/check-focused-tests-cli.spec.ts
+++ b/src/testing/check-focused-tests-cli.spec.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { writeFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = process.cwd();
+const cliPath = path.join(repositoryRoot, 'scripts/check-focused-tests.mjs');
+const temporaryViolationPath = path.join(
+  repositoryRoot,
+  'scripts/__focused-test-cli-regression__.test.mjs',
+);
+
+type CliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+async function runFocusedTestsCli() {
+  return new Promise<CliResult>((resolve, reject) => {
+    execFile(process.execPath, [cliPath], {
+      cwd: repositoryRoot,
+      env: process.env,
+    }, (error, stdout, stderr) => {
+      if (error && typeof error === 'object' && 'code' in error) {
+        resolve({
+          exitCode: Number(error.code),
+          stdout,
+          stderr,
+        });
+        return;
+      }
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve({
+        exitCode: 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+describe('check-focused-tests CLI', () => {
+  afterEach(async () => {
+    await rm(temporaryViolationPath, { force: true });
+  });
+
+  it('exits successfully when the repository has no focused tests', async () => {
+    const result = await runFocusedTestsCli();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Focused test check passed.');
+    expect(result.stderr).toBe('');
+  });
+
+  it('exits with a violation report when a committed focused test is present', async () => {
+    await writeFile(temporaryViolationPath, "fit('temporary focused test', () => {});\n");
+
+    const result = await runFocusedTestsCli();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Focused test check failed. Remove committed focused tests:');
+    expect(result.stderr).toContain('scripts/__focused-test-cli-regression__.test.mjs:1 (fit)');
+  });
+});

--- a/src/testing/check-focused-tests-cli.spec.ts
+++ b/src/testing/check-focused-tests-cli.spec.ts
@@ -69,4 +69,32 @@ describe('check-focused-tests CLI', () => {
     expect(result.stderr).toContain('Focused test check failed. Remove committed focused tests:');
     expect(result.stderr).toContain('scripts/__focused-test-cli-regression__.test.mjs:1 (fit)');
   });
+
+  it('reports focused .only.each chains as committed violations', async () => {
+    await writeFile(
+      temporaryViolationPath,
+      "test.only.each([[1]])('temporary focused test %s', () => {});\n",
+    );
+
+    const result = await runFocusedTestsCli();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Focused test check failed. Remove committed focused tests:');
+    expect(result.stderr).toContain('scripts/__focused-test-cli-regression__.test.mjs:1 (.only)');
+  });
+
+  it('reports chained Vitest focus APIs as committed violations', async () => {
+    await writeFile(
+      temporaryViolationPath,
+      "test.concurrent.only('temporary focused test', () => {});\n",
+    );
+
+    const result = await runFocusedTestsCli();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Focused test check failed. Remove committed focused tests:');
+    expect(result.stderr).toContain('scripts/__focused-test-cli-regression__.test.mjs:1 (.only)');
+  });
 });

--- a/src/testing/node-test-harness.d.ts
+++ b/src/testing/node-test-harness.d.ts
@@ -1,0 +1,36 @@
+declare module 'node:child_process' {
+  export function execFile(
+    file: string,
+    args: readonly string[],
+    options: {
+      cwd?: string;
+      env?: Record<string, string | undefined>;
+    },
+    callback: (error: ExecFileError | null, stdout: string, stderr: string) => void,
+  ): void;
+
+  export interface ExecFileError extends Error {
+    code?: number | string;
+    stdout?: string;
+    stderr?: string;
+  }
+}
+
+declare module 'node:fs/promises' {
+  export function writeFile(path: string, data: string): Promise<void>;
+  export function rm(path: string, options?: { force?: boolean }): Promise<void>;
+}
+
+declare module 'node:path' {
+  const path: {
+    join: (...parts: string[]) => string;
+  };
+
+  export default path;
+}
+
+declare const process: {
+  cwd(): string;
+  execPath: string;
+  env: Record<string, string | undefined>;
+};


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- add a repository-local focused-test guard for committed test files
- run the guard in pull request CI before the Angular test suite
- add regression coverage for helper parsing and the CLI contract, and document the change in the changelog

## Changes
| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Run the focused-test guard before `npm test` in PR CI |
| `package.json` | Add focused-test check and regression test scripts |
| `scripts/check-focused-tests.mjs` | Scan repository test files for focused-test patterns |
| `scripts/check-focused-tests.test.mjs` | Cover parser and focused-pattern regression cases |
| `src/testing/check-focused-tests-cli.spec.ts` | Verify the CLI exit/error contract used by CI |
| `src/testing/node-test-harness.d.ts` | Provide minimal Node typings for the CLI contract spec |
| `README.md` | Note that committed focused tests fail CI |
| `CHANGELOG.md` | Record the new focused-test CI guard in Unreleased |

## Test Plan
- [x] `npm run check:focused-tests`
- [x] `npm run test:focused-tests`
- [x] `npm test -- --watch=false --include src/testing/check-focused-tests-cli.spec.ts`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A: no shell scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers