### PR TITLE
ci(a11y): add axe accessibility checks to CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
 - **Node 22 LTS CI Runtime**: Pinned the GitHub Actions Node.js test workflow to Node 22 LTS and documented Node 22 LTS in the README as the recommended local version because it matches CI.
 - **Focused Test CI Guard**: Added a repository-level guard that fails pull request CI when committed focused tests such as `.only`, `fit`, `fdescribe`, or `.only.each(...)` are present, with regression coverage for the checker and its CLI contract.
+- **Automated Axe Accessibility Checks**: Added reusable axe-core assertions for covered `app-finder`, `app-card`, `app-categories`, and `dashboard` render states. Because CI already runs `npm test`, violations found by those checks now fail the existing test workflow automatically.
+
+### Documentation
+
+- **Accessibility Testing Policy**: Documented that `npm test` includes axe-core accessibility checks for the covered component states, and that the jsdom helper excludes `color-contrast` until browser-level support is available.
 
 ### Changed Files
 
@@ -19,15 +24,24 @@
 - `README.md`
 - `CHANGELOG.md`
 - `package.json`
+- `package-lock.json`
 - `scripts/check-focused-tests.mjs`
 - `scripts/check-focused-tests.test.mjs`
 - `src/testing/check-focused-tests-cli.spec.ts`
 - `src/testing/node-test-harness.d.ts`
+- `src/testing/a11y.ts`
 - `src/app/core/initializers/dashboard.initializer.ts`
 - `src/app/core/services/app.service.ts`
 - `src/app/core/services/logger.service.ts`
 - `src/app/core/services/logger.service.spec.ts`
 - `src/app/core/services/yaml-loader.service.ts`
+- `src/app/shared/components/app-card/app-card.component.html`
+- `src/app/shared/components/app-card/app-card.component.spec.ts`
+- `src/app/shared/components/app-card/app-card.component.ts`
+- `src/app/shared/components/app-categories/app-categories.component.spec.ts`
+- `src/app/shared/components/app-finder/app-finder.component.spec.ts`
+- `src/app/views/dashboard/dashboard.component.html`
+- `src/app/views/dashboard/dashboard.component.spec.ts`
 - `src/app/views/dashboard/dashboard.component.ts`
 
 ## v1.0.1

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ npm run build
 npm test
 ```
 
+`npm test` includes axe-core accessibility assertions for the rendered `app-finder`, `app-card`, `app-categories`, and `dashboard` states covered by the component specs, so the existing CI test job fails on violations found in those checks. The shared jsdom helper currently disables axe's `color-contrast` rule because that rule needs browser APIs that are not reliably available in this test environment.
+
 ### Development Server
 
 The dev server runs on `http://localhost:4200` with hot-reload enabled.
@@ -585,6 +587,7 @@ Contributions are welcome! Please feel free to submit issues or pull requests.
 - Write tests for new features
 - Do not commit focused tests such as `.only`, `fit`, or `fdescribe`; CI fails fast on them
 - Ensure accessibility (WCAG AA)
+- Keep axe-core component accessibility checks passing; they run as part of `npm test` for the covered component states, with `color-contrast` excluded in jsdom
 - Keep components small and focused
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/js-yaml": "^4.0.9",
+        "axe-core": "^4.11.0",
         "jsdom": "^27.1.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.12",
@@ -4651,6 +4652,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.9",
+    "axe-core": "^4.11.0",
     "jsdom": "^27.1.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.12",

--- a/src/app/shared/components/app-card/app-card.component.html
+++ b/src/app/shared/components/app-card/app-card.component.html
@@ -1,11 +1,8 @@
-<article
-  class="bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl h-full p-6 cursor-pointer flex flex-col items-center text-center transition-all duration-300 hover:bg-white/15 hover:shadow-2xl hover:border-white/30 hover:-translate-y-1 hover:scale-105 group"
-  role="button"
-  tabindex="0"
+<button
+  class="w-full bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl h-full p-6 cursor-pointer flex flex-col items-center text-center transition-all duration-300 hover:bg-white/15 hover:shadow-2xl hover:border-white/30 hover:-translate-y-1 hover:scale-105 group"
+  type="button"
   [attr.aria-label]="'Open ' + app().name"
   (click)="openApp()"
-  (keydown.enter)="openApp()"
-  (keydown)="onKeydown($event)"
 >
   <!-- Icon container -->
   <div class="relative mb-4">
@@ -19,11 +16,11 @@
 
   <!-- App info -->
   <div class="flex flex-col items-center text-center flex-1">
-    <h3
-      class="font-semibold text-neutral-800 dark:text-white text-lg mb-2 group-hover:text-neutral-800/90 dark:group-hover:text-white/90 transition-all duration-300"
-    >
-      {{ app().name }}
-    </h3>
+      <p
+        class="font-semibold text-neutral-800 dark:text-white text-lg mb-2 group-hover:text-neutral-800/90 dark:group-hover:text-white/90 transition-all duration-300"
+      >
+        {{ app().name }}
+      </p>
 
     @if (showDescriptions) {
       <p
@@ -50,4 +47,4 @@
   <div
     class="absolute inset-0 rounded-3xl ring-2 ring-white/0 focus-visible:ring-white/50 transition-all duration-300 pointer-events-none"
   ></div>
-</article>
+</button>

--- a/src/app/shared/components/app-card/app-card.component.spec.ts
+++ b/src/app/shared/components/app-card/app-card.component.spec.ts
@@ -4,11 +4,11 @@ import {BehaviorSubject} from 'rxjs';
 
 import {AppCardComponent} from './app-card.component';
 
-import {AppService} from '../../../core/services/app.service';
 import {IconService} from '../../../core/services/icon.service';
 import {SettingsService} from '../../../core/services/settings.service';
 
 import {DEFAULT_DASHBOARD_CONFIG, SelfhostedApp} from '../../../core/models/dashboard.models';
+import {expectNoAxeViolations} from '../../../../testing/a11y';
 
 describe('AppCardComponent', () => {
   const settingsSubject = new BehaviorSubject(DEFAULT_DASHBOARD_CONFIG.settings);
@@ -44,10 +44,6 @@ describe('AppCardComponent', () => {
       },
       providers: [
         {
-          provide: AppService,
-          useValue: {},
-        },
-        {
           provide: IconService,
           useValue: iconServiceMock,
         },
@@ -77,6 +73,12 @@ describe('AppCardComponent', () => {
     expect(screen.getByText('video')).toBeInTheDocument();
     expect(screen.getByText('streaming')).toBeInTheDocument();
     expect(screen.getByAltText('Plex icon')).toHaveAttribute('src', 'https://example.com/icons/plex.png');
+  });
+
+  it('should have no accessibility violations', async () => {
+    const view = await setup();
+
+    await expectNoAxeViolations(view.container);
   });
 
   it('should not render the description when showDescriptions is disabled', async () => {
@@ -146,6 +148,7 @@ describe('AppCardComponent', () => {
   });
 
   it('should support keyboard activation with Space', async () => {
+    const user = userEvent.setup();
     const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const view = await setup();
     const appClickSpy = vi.fn();
@@ -155,8 +158,7 @@ describe('AppCardComponent', () => {
     const appCard = screen.getByRole('button', {name: 'Open Plex'});
     appCard.focus();
 
-    appCard.dispatchEvent(new KeyboardEvent('keydown', {key: ' ', code: 'Space', bubbles: true, cancelable: true}));
-    appCard.dispatchEvent(new KeyboardEvent('keyup', {key: ' ', code: 'Space', bubbles: true}));
+    await user.keyboard(' ');
 
     expect(windowOpenSpy).toHaveBeenCalledWith('https://plex.example.com', '_blank');
     expect(windowOpenSpy).toHaveBeenCalledTimes(1);

--- a/src/app/shared/components/app-card/app-card.component.ts
+++ b/src/app/shared/components/app-card/app-card.component.ts
@@ -4,7 +4,6 @@ import {CommonModule} from '@angular/common';
 import {SelfhostedApp} from '../../../core/models/dashboard.models';
 
 import {IconService} from '../../../core/services/icon.service';
-import {AppService} from '../../../core/services/app.service';
 import {SettingsService} from '../../../core/services/settings.service';
 
 @Component({
@@ -18,7 +17,6 @@ import {SettingsService} from '../../../core/services/settings.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppCardComponent {
-  private readonly appService = inject(AppService);
   private readonly settingsService = inject(SettingsService);
 
   // Inputs
@@ -40,16 +38,6 @@ export class AppCardComponent {
 
   get showLabels(): boolean {
     return this.settingsService.settingsSubject.value.showLabels;
-  }
-
-  /**
-   * Handle keydown events for keyboard accessibility
-   */
-  onKeydown(event: KeyboardEvent): void {
-    if (event.key === ' ' || event.code === 'Space') {
-      event.preventDefault();
-      this.openApp();
-    }
   }
 
   /**

--- a/src/app/shared/components/app-categories/app-categories.component.spec.ts
+++ b/src/app/shared/components/app-categories/app-categories.component.spec.ts
@@ -9,6 +9,7 @@ import {CategoryService} from '../../../core/services/category.service';
 import {SearchService} from '../../../core/services/search.service';
 
 import {APP_CATEGORY, FAVORITES_CATEGORY, Category} from '../../../core/models/dashboard.models';
+import {expectNoAxeViolations} from '../../../../testing/a11y';
 
 describe('AppCategoriesComponent', () => {
   const categories: Category[] = [
@@ -60,6 +61,12 @@ describe('AppCategoriesComponent', () => {
     expect(screen.getByRole('navigation', {name: 'Categories'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Apps'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Media'})).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('should have no accessibility violations', async () => {
+    const view = await setup();
+
+    await expectNoAxeViolations(view.container);
   });
 
   it('should change the category through AppService', async () => {

--- a/src/app/shared/components/app-finder/app-finder.component.spec.ts
+++ b/src/app/shared/components/app-finder/app-finder.component.spec.ts
@@ -8,16 +8,17 @@ import {AppService} from '../../../core/services/app.service';
 import {SearchService} from '../../../core/services/search.service';
 
 import {DEFAULT_DASHBOARD_SEARCH_ENGINES, SearchEngine} from '../../../core/models/dashboard.models';
+import {expectNoAxeViolations} from '../../../../testing/a11y';
 
 describe('AppFinderComponent', () => {
   const appServiceMock = {
     setSearchQuery: vi.fn(),
   };
 
-  const setup = async (searchEngines: SearchEngine[] = []): Promise<void> => {
+  const setup = async (searchEngines: SearchEngine[] = []) => {
     appServiceMock.setSearchQuery.mockReset();
 
-    await render(AppFinderComponent, {
+    return render(AppFinderComponent, {
       providers: [
         {
           provide: AppService,
@@ -44,6 +45,48 @@ describe('AppFinderComponent', () => {
       'placeholder',
       'Search on your applications...',
     );
+  });
+
+  it('should have no accessibility violations in local search mode', async () => {
+    const view = await render(AppFinderComponent, {
+      providers: [
+        {
+          provide: AppService,
+          useValue: appServiceMock,
+        },
+        {
+          provide: SearchService,
+          useValue: {
+            searchEngines$: of([]),
+          },
+        },
+      ],
+    });
+
+    await expectNoAxeViolations(view.container);
+  });
+
+  it('should have no accessibility violations when the engine dropdown is open', async () => {
+    const user = userEvent.setup();
+    const googleEngine = DEFAULT_DASHBOARD_SEARCH_ENGINES[0];
+
+    const view = await setup([googleEngine]);
+
+    await user.click(screen.getByRole('button', {name: 'Select search engine'}));
+
+    await expectNoAxeViolations(view.container);
+  });
+
+  it('should have no accessibility violations when active search controls are visible', async () => {
+    const user = userEvent.setup();
+    const view = await setup();
+
+    await user.type(screen.getByRole('searchbox', {name: 'Search applications'}), 'radarr');
+
+    expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+
+    await expectNoAxeViolations(view.container);
   });
 
   it('should propagate search input to AppService when no engine is selected', async () => {

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -14,15 +14,16 @@
 
     @if (filteredApps$ | async; as apps) {
       @if (apps.length > 0) {
-        <section
+        <ul
           aria-label="Applications"
-          role="list"
           [class]="`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-${itemsPerRow} gap-4 md:gap-6`"
         >
           @for (app of apps; track app.id) {
-            <app-card [app]="app" (appClick)="onAppClick(app)"></app-card>
+            <li>
+              <app-card [app]="app" (appClick)="onAppClick(app)"></app-card>
+            </li>
           }
-        </section>
+        </ul>
       } @else {
         <!-- Empty state -->
         <section

--- a/src/app/views/dashboard/dashboard.component.spec.ts
+++ b/src/app/views/dashboard/dashboard.component.spec.ts
@@ -12,6 +12,7 @@ import {CategoryService} from '../../core/services/category.service';
 import {IconService} from '../../core/services/icon.service';
 
 import {APP_CATEGORY, DEFAULT_DASHBOARD_CONFIG, DashboardSettings, SelfhostedApp} from '../../core/models/dashboard.models';
+import {expectNoAxeViolations} from '../../../testing/a11y';
 
 describe('DashboardComponent', () => {
   const appFixture: SelfhostedApp = {
@@ -141,6 +142,146 @@ describe('DashboardComponent', () => {
     expect(screen.getByText('Loading dashboard...')).toBeInTheDocument();
     expect(screen.queryByRole('list', {name: 'Applications'})).not.toBeInTheDocument();
     expect(screen.queryByText('No applications found')).not.toBeInTheDocument();
+  });
+
+  it('should have no accessibility violations when applications are rendered', async () => {
+    const secondAppFixture: SelfhostedApp = {
+      ...appFixture,
+      id: 'radarr',
+      name: 'Radarr',
+      url: 'https://radarr.example.com',
+      favorite: false,
+    };
+
+    const view = await render(DashboardComponent, {
+      providers: [
+        {
+          provide: AppService,
+          useValue: {
+            ...appServiceMock,
+            filteredApps$: of([appFixture, secondAppFixture]),
+          },
+        },
+        {
+          provide: SearchService,
+          useValue: {
+            searchQuery$: of(''),
+            searchEngines$: of([]),
+            haveSearchSubject,
+          },
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            settings$: settingsSubject.asObservable(),
+            settingsSubject,
+          },
+        },
+        {
+          provide: ThemeService,
+          useValue: {
+            themeSubject,
+            isDarkMode: () => themeSubject.value === 'dark',
+            toggleTheme: vi.fn(),
+          },
+        },
+        {
+          provide: MetadataService,
+          useValue: {
+            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+          },
+        },
+        {
+          provide: CategoryService,
+          useValue: {
+            categories$: of([APP_CATEGORY]),
+            selectedCategory$: selectedCategorySubject,
+          },
+        },
+        {
+          provide: IconService,
+          useValue: iconServiceMock,
+        },
+      ],
+    });
+
+    await expectNoAxeViolations(view.container);
+  });
+
+  it('should have no accessibility violations in the loading state', async () => {
+    const filteredAppsSubject = new Subject<SelfhostedApp[]>();
+
+    const view = await render(DashboardComponent, {
+      providers: [
+        {
+          provide: AppService,
+          useValue: {
+            ...appServiceMock,
+            filteredApps$: filteredAppsSubject.asObservable(),
+          },
+        },
+        {
+          provide: SearchService,
+          useValue: {
+            searchQuery$: of(''),
+            searchEngines$: of([]),
+            haveSearchSubject,
+          },
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            settings$: settingsSubject.asObservable(),
+            settingsSubject,
+          },
+        },
+        {
+          provide: ThemeService,
+          useValue: {
+            themeSubject,
+            isDarkMode: () => themeSubject.value === 'dark',
+            toggleTheme: vi.fn(),
+          },
+        },
+        {
+          provide: MetadataService,
+          useValue: {
+            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+          },
+        },
+        {
+          provide: CategoryService,
+          useValue: {
+            categories$: of([APP_CATEGORY]),
+            selectedCategory$: selectedCategorySubject,
+          },
+        },
+        {
+          provide: IconService,
+          useValue: iconServiceMock,
+        },
+      ],
+    });
+
+    await expectNoAxeViolations(view.container);
+  });
+
+  it('should have no accessibility violations in the empty search state', async () => {
+    await setup({
+      filteredApps$: of([]),
+      searchQuery$: of('plex'),
+    });
+
+    await expectNoAxeViolations(document.body);
+  });
+
+  it('should have no accessibility violations in the empty default state', async () => {
+    await setup({
+      filteredApps$: of([]),
+      searchQuery$: of(''),
+    });
+
+    await expectNoAxeViolations(document.body);
   });
 
   it('should render the applications grid when apps are available', async () => {

--- a/src/testing/a11y.ts
+++ b/src/testing/a11y.ts
@@ -1,0 +1,30 @@
+import * as axe from 'axe-core';
+import {expect} from 'vitest';
+
+const AXE_OPTIONS: axe.RunOptions = {
+  rules: {
+    'color-contrast': {
+      enabled: false,
+    },
+  },
+};
+
+const formatViolations = (violations: axe.Result[]): string =>
+  violations
+    .map((violation: axe.Result) => {
+      const impactedNodes = violation.nodes
+        .map(
+          (node: axe.NodeResult) =>
+            `${node.target.join(' ')} → ${node.failureSummary ?? 'No failure summary provided.'}`,
+        )
+        .join('\n');
+
+      return `${violation.id}: ${violation.help}\n${impactedNodes}`;
+    })
+    .join('\n\n');
+
+export async function expectNoAxeViolations(container: Element): Promise<void> {
+  const {violations} = await axe.run(container, AXE_OPTIONS);
+
+  expect(violations, formatViolations(violations)).toHaveLength(0);
+}


### PR DESCRIPTION
Closes #40

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- add a shared axe-core helper for Angular/Vitest accessibility assertions
- cover app-finder, app-card, app-categories, and dashboard accessibility states
- fix the semantic and layout regressions needed to keep the UI and docs aligned with the new checks

## Changes
| File | Change |
|------|--------|
| src/testing/a11y.ts | Added the shared axe helper used by component and view specs |
| src/app/shared/components/app-finder/app-finder.component.spec.ts | Added accessibility coverage for idle, active-search, and open-dropdown states |
| src/app/shared/components/app-card/app-card.component.html, src/app/shared/components/app-card/app-card.component.ts, src/app/shared/components/app-card/app-card.component.spec.ts | Switched the card to a native button, restored full-width layout, and updated tests |
| src/app/shared/components/app-categories/app-categories.component.spec.ts | Added axe-based accessibility coverage |
| src/app/views/dashboard/dashboard.component.html, src/app/views/dashboard/dashboard.component.spec.ts | Restored list semantics and added accessibility coverage for populated, loading, and empty states |
| package.json, package-lock.json | Added axe-core dev dependency |
| README.md, CHANGELOG.md | Documented the accessibility test policy and unreleased change |

## Test Plan
- [x] npm test -- --watch=false
- [x] npm run build
- [x] Manually tested the affected functionality in local app startup
- [x] No modified shell scripts required shellcheck

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] No modified shell scripts to check with shellcheck
- [x] Docs updated because behavior changed
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers
