### PR TITLE
fix(components): keep OnPush views reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
 - **Production Logging Cleanup**: Replaced development-only `console.log` usage in dashboard initialization and config loading flows with a centralized logger service, while removing the dashboard click debug log from production code.
 
+### Performance
+
+- **OnPush Change Detection**: Enabled `ChangeDetectionStrategy.OnPush` across all application components and made theme and card visibility state signal-reactive so their rendered values remain current without unnecessary tree-wide change detection.
+
 ### CI / Tooling
 
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
@@ -41,11 +45,18 @@
 - `src/app/core/services/logger.service.ts`
 - `src/app/core/services/logger.service.spec.ts`
 - `src/app/core/services/yaml-loader.service.ts`
+- `src/app/app.ts`
 - `src/app/shared/components/app-card/app-card.component.html`
 - `src/app/shared/components/app-card/app-card.component.spec.ts`
 - `src/app/shared/components/app-card/app-card.component.ts`
+- `src/app/shared/components/app-clock/app-clock.component.spec.ts`
+- `src/app/shared/components/app-clock/app-clock.component.ts`
 - `src/app/shared/components/app-categories/app-categories.component.spec.ts`
 - `src/app/shared/components/app-finder/app-finder.component.spec.ts`
+- `src/app/shared/components/app-footer/app-footer.component.ts`
+- `src/app/shared/components/app-header/app-header.component.spec.ts`
+- `src/app/shared/components/app-header/app-header.component.ts`
+- `src/app/shared/components/app-loading/app-loading.component.ts`
 - `src/app/views/dashboard/dashboard.component.html`
 - `src/app/views/dashboard/dashboard.component.spec.ts`
 - `src/app/views/dashboard/dashboard.component.ts`

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { DashboardComponent } from './views/dashboard/dashboard.component';
 
@@ -7,5 +7,6 @@ import { DashboardComponent } from './views/dashboard/dashboard.component';
   imports: [DashboardComponent],
   templateUrl: 'app.html',
   styleUrl: 'app.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App {}

--- a/src/app/shared/components/app-card/app-card.component.html
+++ b/src/app/shared/components/app-card/app-card.component.html
@@ -22,7 +22,7 @@
       {{ app().name }}
     </p>
 
-    @if (showDescriptions) {
+    @if (showDescriptions()) {
       <p
         class="text-sm text-neutral-800/70 dark:text-white/70 line-clamp-2 group-hover:text-neutral-800/80 dark:group-hover:text-white/80 transition-all duration-300"
       >
@@ -30,7 +30,7 @@
       </p>
     }
 
-    @if (showLabels && app().tags.length > 0) {
+    @if (showLabels() && app().tags.length > 0) {
       <div class="flex flex-wrap gap-1 mt-3 justify-center">
         @for (tag of app().tags; track tag) {
           <span

--- a/src/app/shared/components/app-card/app-card.component.spec.ts
+++ b/src/app/shared/components/app-card/app-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { BehaviorSubject } from 'rxjs';
 
@@ -101,6 +101,25 @@ describe('AppCardComponent', () => {
 
     expect(screen.queryByText('video')).not.toBeInTheDocument();
     expect(screen.queryByText('streaming')).not.toBeInTheDocument();
+  });
+
+  it('should update description and tag visibility when settings change after render', async () => {
+    await setup();
+
+    expect(screen.getByText('Media server')).toBeInTheDocument();
+    expect(screen.getByText('video')).toBeInTheDocument();
+
+    settingsSubject.next({
+      ...DEFAULT_DASHBOARD_CONFIG.settings,
+      showDescriptions: false,
+      showLabels: false,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Media server')).not.toBeInTheDocument();
+      expect(screen.queryByText('video')).not.toBeInTheDocument();
+      expect(screen.queryByText('streaming')).not.toBeInTheDocument();
+    });
   });
 
   it('should open the app in a new tab and emit appClick on click', async () => {

--- a/src/app/shared/components/app-card/app-card.component.ts
+++ b/src/app/shared/components/app-card/app-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, input, output, ChangeDetectionStrategy, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { SelfhostedApp } from '../../../core/models/dashboard.models';
 
@@ -18,6 +19,7 @@ import { SettingsService } from '../../../core/services/settings.service';
 })
 export class AppCardComponent {
   private readonly settingsService = inject(SettingsService);
+  private readonly settings = toSignal(this.settingsService.settingsSubject, { requireSync: true });
 
   // Inputs
   readonly app = input.required<SelfhostedApp>();
@@ -32,13 +34,8 @@ export class AppCardComponent {
    */
   readonly iconUrl = computed(() => this.iconService.getIconUrl(this.app()));
 
-  get showDescriptions(): boolean {
-    return this.settingsService.settingsSubject.value.showDescriptions;
-  }
-
-  get showLabels(): boolean {
-    return this.settingsService.settingsSubject.value.showLabels;
-  }
+  readonly showDescriptions = computed(() => this.settings().showDescriptions);
+  readonly showLabels = computed(() => this.settings().showLabels);
 
   /**
    * Open application

--- a/src/app/shared/components/app-clock/app-clock.component.spec.ts
+++ b/src/app/shared/components/app-clock/app-clock.component.spec.ts
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/angular';
+import { BehaviorSubject } from 'rxjs';
+
+import { DEFAULT_DASHBOARD_CONFIG, DashboardSettings } from '../../../core/models/dashboard.models';
+import { SettingsService } from '../../../core/services/settings.service';
+
+import { AppClockComponent } from './app-clock.component';
+
+describe('AppClockComponent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates the rendered time every second under OnPush', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+    const settingsSubject = new BehaviorSubject<DashboardSettings>({
+      ...DEFAULT_DASHBOARD_CONFIG.settings,
+      showDate: false,
+      showSeconds: true,
+    });
+
+    await render(AppClockComponent, {
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: { settingsSubject },
+        },
+      ],
+    });
+
+    expect(screen.getByText('00')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(1001);
+
+    expect(screen.getByText('01')).toBeInTheDocument();
+  });
+});

--- a/src/app/shared/components/app-clock/app-clock.component.ts
+++ b/src/app/shared/components/app-clock/app-clock.component.ts
@@ -1,13 +1,20 @@
 import { CommonModule, NgTemplateOutlet } from '@angular/common';
-import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnDestroy,
+  OnInit,
+  signal,
+} from '@angular/core';
 
 import { SettingsService } from '../../../core/services/settings.service';
 
 @Component({
   selector: 'app-clock',
-  standalone: true,
   imports: [CommonModule, NgTemplateOutlet],
   templateUrl: 'app-clock.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppClockComponent implements OnInit, OnDestroy {
   private readonly settingsService = inject(SettingsService);

--- a/src/app/shared/components/app-footer/app-footer.component.ts
+++ b/src/app/shared/components/app-footer/app-footer.component.ts
@@ -1,13 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { AppService } from '../../../core/services/app.service';
 
 @Component({
   selector: 'app-footer',
-  standalone: true,
   imports: [CommonModule],
   templateUrl: 'app-footer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppFooterComponent {
   private appService = inject(AppService);

--- a/src/app/shared/components/app-header/app-header.component.spec.ts
+++ b/src/app/shared/components/app-header/app-header.component.spec.ts
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { Mock } from 'vitest';
 import { CommonModule } from '@angular/common';
+import { signal } from '@angular/core';
 import { of } from 'rxjs';
 
 import { AppHeaderComponent } from './app-header.component';
@@ -12,14 +13,14 @@ import { MetadataService } from '../../../core/services/metadata.service';
 import { DEFAULT_DASHBOARD_CONFIG } from '../../../core/models/dashboard.models';
 
 describe('AppHeader', () => {
-  const setup = async (toggleThemeMock?: Mock): Promise<void> => {
+  const setup = async (toggleThemeMock?: Mock, isDark = signal(true)): Promise<void> => {
     await render(AppHeaderComponent, {
       imports: [CommonModule],
       providers: [
         {
           provide: ThemeService,
           useValue: {
-            isDarkMode: () => true,
+            isDark,
             toggleTheme: toggleThemeMock || vi.fn(),
           },
         },
@@ -56,6 +57,20 @@ describe('AppHeader', () => {
 
       expect(toggleThemeMock).toBeCalled();
       expect(toggleThemeMock).toBeCalledTimes(1);
+    });
+
+    it('should update the presented theme when the active theme changes', async () => {
+      const isDark = signal(true);
+      await setup(undefined, isDark);
+
+      expect(screen.getByText('🌙')).toBeInTheDocument();
+
+      isDark.set(false);
+
+      await waitFor(() => {
+        expect(screen.getByText('☀️')).toBeInTheDocument();
+        expect(screen.queryByText('🌙')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/app/shared/components/app-header/app-header.component.ts
+++ b/src/app/shared/components/app-header/app-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -7,9 +7,9 @@ import { MetadataService } from '../../../core/services/metadata.service';
 
 @Component({
   selector: 'app-header',
-  standalone: true,
   imports: [CommonModule],
   templateUrl: 'app-header.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppHeaderComponent {
   private readonly themeService = inject(ThemeService);
@@ -17,8 +17,8 @@ export class AppHeaderComponent {
 
   readonly metadata = toSignal(this.metadataService.metadata$);
 
-  readonly themeIcon = computed(() => (this.themeService.isDarkMode() ? '🌙' : '☀️'));
-  readonly themeText = computed(() => (this.themeService.isDarkMode() ? 'Dark' : 'Light'));
+  readonly themeIcon = computed(() => (this.themeService.isDark() ? '🌙' : '☀️'));
+  readonly themeText = computed(() => (this.themeService.isDark() ? 'Dark' : 'Light'));
 
   onToggleTheme(): void {
     this.themeService.toggleTheme();

--- a/src/app/shared/components/app-loading/app-loading.component.ts
+++ b/src/app/shared/components/app-loading/app-loading.component.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'app-loading',
-  standalone: true,
   imports: [CommonModule],
   templateUrl: 'app-loading.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppLoadingComponent {}

--- a/src/app/views/dashboard/dashboard.component.spec.ts
+++ b/src/app/views/dashboard/dashboard.component.spec.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/angular';
+import { signal } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
@@ -39,6 +40,7 @@ describe('DashboardComponent', () => {
   const selectedCategorySubject = new BehaviorSubject<string>(APP_CATEGORY.id);
   const haveSearchSubject = new BehaviorSubject<boolean>(false);
   const themeSubject = new BehaviorSubject<'light' | 'dark' | 'auto'>('dark');
+  const isDark = signal(true);
 
   const appServiceMock = {
     appVersion: '0.2.0-test',
@@ -87,6 +89,7 @@ describe('DashboardComponent', () => {
     haveSearchSubject.next(false);
     selectedCategorySubject.next(APP_CATEGORY.id);
     themeSubject.next(isDarkMode ? 'dark' : 'light');
+    isDark.set(isDarkMode);
     appServiceMock.filteredApps$ = filteredApps$;
 
     await render(DashboardComponent, {
@@ -114,6 +117,7 @@ describe('DashboardComponent', () => {
           provide: ThemeService,
           useValue: {
             themeSubject,
+            isDark,
             isDarkMode: () => themeSubject.value === 'dark',
             toggleTheme: vi.fn(),
           },
@@ -188,6 +192,7 @@ describe('DashboardComponent', () => {
           provide: ThemeService,
           useValue: {
             themeSubject,
+            isDark,
             isDarkMode: () => themeSubject.value === 'dark',
             toggleTheme: vi.fn(),
           },
@@ -246,6 +251,7 @@ describe('DashboardComponent', () => {
           provide: ThemeService,
           useValue: {
             themeSubject,
+            isDark,
             isDarkMode: () => themeSubject.value === 'dark',
             toggleTheme: vi.fn(),
           },


### PR DESCRIPTION
## Linked issue

Closes #32

## Type

- [x] Bug fix

## Summary

- Enable `ChangeDetectionStrategy.OnPush` across all current application components.
- Keep theme and card visibility rendering reactive after initial render.
- Add behavior-focused coverage for clock, theme, and card updates.
- Document the performance change in the changelog.

## Test plan

- [x] `npm test` (85 tests)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`

## Contributor checklist

- [x] Linked an approved issue
- [x] Used a conventional commit
- [x] Updated documentation
- [x] Added no AI attribution