### PR TITLE
fix(state): align synchronous state with signals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,13 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 ## State Management
 
-- Use signals for local component state
+- Use signals for component-local state, derived state, and synchronous application or UI state
 - Use `computed()` for derived state
 - Keep state transformations pure and predictable
 - Do NOT use `mutate` on signals, use `update` or `set` instead
+- Use RxJS for genuinely asynchronous streams such as HTTP, browser events, debouncing, or multi-source async orchestration
+- Do not use `BehaviorSubject` as a general-purpose state container; expose readonly signals and update state through service methods
+- Use `toSignal()` only at a component or service boundary that consumes a genuine RxJS stream
 
 ## Templates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Performance
 
 - **OnPush Change Detection**: Enabled `ChangeDetectionStrategy.OnPush` across all application components and made theme and card visibility state signal-reactive so their rendered values remain current without unnecessary tree-wide change detection.
+- **Signal-Based Application State**: Migrated synchronous configuration, settings, search, category, bookmark, metadata, filtering, and theme state to Angular signals while retaining RxJS only for asynchronous YAML loading. Theme initialization now tolerates unavailable browser storage and reconciles delayed YAML configuration without overriding user preferences.
 
 ### CI / Tooling
 
@@ -27,6 +28,7 @@
 ### Changed Files
 
 - `.github/workflows/test.yml`
+- `AGENTS.md`
 - `README.md`
 - `CHANGELOG.md`
 - `package.json`
@@ -41,9 +43,20 @@
 - `src/testing/node-test-harness.d.ts`
 - `src/testing/a11y.ts`
 - `src/app/core/initializers/dashboard.initializer.ts`
+- `src/app/core/services/app.service.spec.ts`
 - `src/app/core/services/app.service.ts`
+- `src/app/core/services/bookmark.service.ts`
+- `src/app/core/services/category.service.spec.ts`
+- `src/app/core/services/category.service.ts`
+- `src/app/core/services/config.service.ts`
 - `src/app/core/services/logger.service.ts`
 - `src/app/core/services/logger.service.spec.ts`
+- `src/app/core/services/metadata.service.ts`
+- `src/app/core/services/search.service.spec.ts`
+- `src/app/core/services/search.service.ts`
+- `src/app/core/services/settings.service.ts`
+- `src/app/core/services/theme.service.spec.ts`
+- `src/app/core/services/theme.service.ts`
 - `src/app/core/services/yaml-loader.service.ts`
 - `src/app/app.ts`
 - `src/app/shared/components/app-card/app-card.component.html`
@@ -52,7 +65,9 @@
 - `src/app/shared/components/app-clock/app-clock.component.spec.ts`
 - `src/app/shared/components/app-clock/app-clock.component.ts`
 - `src/app/shared/components/app-categories/app-categories.component.spec.ts`
+- `src/app/shared/components/app-categories/app-categories.component.ts`
 - `src/app/shared/components/app-finder/app-finder.component.spec.ts`
+- `src/app/shared/components/app-finder/app-finder.component.ts`
 - `src/app/shared/components/app-footer/app-footer.component.ts`
 - `src/app/shared/components/app-header/app-header.component.spec.ts`
 - `src/app/shared/components/app-header/app-header.component.ts`

--- a/src/app/core/services/app.service.spec.ts
+++ b/src/app/core/services/app.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { signal } from '@angular/core';
+import { of } from 'rxjs';
 
 import { AppService } from './app.service';
 import { ConfigService } from './config.service';
@@ -19,7 +20,7 @@ import {
 
 describe('AppService', () => {
   let service: AppService;
-  let configSubject: BehaviorSubject<DashboardConfig>;
+  let configState: ReturnType<typeof signal<DashboardConfig | undefined>>;
   let searchService: SearchService;
   let categoryService: CategoryService;
 
@@ -29,7 +30,7 @@ describe('AppService', () => {
   });
 
   beforeEach(() => {
-    configSubject = new BehaviorSubject<DashboardConfig>(createConfig());
+    configState = signal<DashboardConfig | undefined>(createConfig());
 
     TestBed.configureTestingModule({
       providers: [
@@ -39,21 +40,20 @@ describe('AppService', () => {
         {
           provide: ConfigService,
           useValue: {
-            config$: configSubject.asObservable(),
-            subject: configSubject,
-            fireNewSubject: (config: DashboardConfig) => configSubject.next(config),
+            config: configState.asReadonly(),
+            fireNewSubject: (config: DashboardConfig) => configState.set(config),
           },
         },
         {
           provide: YamlLoaderService,
           useValue: {
-            loadDashboardConfig: () => new BehaviorSubject(createConfig()),
+            loadDashboardConfig: () => of(createConfig()),
           },
         },
         {
           provide: BookmarkService,
           useValue: {
-            bookmarks: [],
+            bookmarks: signal([]),
           },
         },
       ],
@@ -67,7 +67,9 @@ describe('AppService', () => {
   describe('apps$', () => {
     it('should assign favorite: false to bookmarks when allowBookmarks is true', async () => {
       const bookmarkServiceMock = TestBed.inject(BookmarkService);
-      (bookmarkServiceMock as unknown as { bookmarks: unknown[] }).bookmarks = [
+      (
+        bookmarkServiceMock as unknown as { bookmarks: ReturnType<typeof signal<unknown[]>> }
+      ).bookmarks.set([
         {
           id: 'google',
           name: 'Google',
@@ -77,9 +79,9 @@ describe('AppService', () => {
           openNewTab: true,
           tags: [],
         },
-      ];
+      ]);
 
-      configSubject.next(
+      configState.set(
         createConfig({
           applications: [],
           bookmarks: [
@@ -100,7 +102,7 @@ describe('AppService', () => {
         }),
       );
 
-      const apps = await firstValueFrom(service.apps$);
+      const apps = service.apps();
       expect(apps).toHaveLength(1);
       expect(apps[0].favorite).toBe(false);
       expect(apps[0].category).toBe(BOOKMARKS_CATEGORY.id);
@@ -109,7 +111,7 @@ describe('AppService', () => {
 
   describe('getAppsByCategory', () => {
     it('should return only favorite apps when categoryId is FAVORITES_CATEGORY.id', () => {
-      configSubject.next(
+      configState.set(
         createConfig({
           applications: [
             {
@@ -144,7 +146,7 @@ describe('AppService', () => {
     });
 
     it('should return all apps for APP_CATEGORY regardless of favorite status', () => {
-      configSubject.next(
+      configState.set(
         createConfig({
           applications: [
             {

--- a/src/app/core/services/app.service.ts
+++ b/src/app/core/services/app.service.ts
@@ -1,6 +1,4 @@
-import { Injectable, inject } from '@angular/core';
-import { Observable, combineLatest } from 'rxjs';
-import { map, distinctUntilChanged } from 'rxjs/operators';
+import { computed, Injectable, inject } from '@angular/core';
 
 import { version } from '../../../../package.json';
 
@@ -21,7 +19,7 @@ import { LoggerService } from './logger.service';
 
 /**
  * Service for managing dashboard application state
- * Uses BehaviorSubjects for reactive state management
+ * Uses signals for synchronous application state.
  */
 @Injectable({ providedIn: 'root' })
 export class AppService {
@@ -37,19 +35,21 @@ export class AppService {
   /**
    * Observable streams for component consumption
    */
-  readonly apps$ = this.configService.config$.pipe(
-    map((config) => [
+  readonly apps = computed(() => {
+    const config = this.configService.config();
+    if (!config) return [];
+    return [
       ...config.applications,
       ...(config.settings.allowBookmarks
-        ? this.bookmarkService.bookmarks.map((bookmark) => ({
+        ? this.bookmarkService.bookmarks().map((bookmark) => ({
             ...bookmark,
             category: BOOKMARKS_CATEGORY.id,
             favorite: false,
           }))
         : []
       ).sort((a, b) => a.name.localeCompare(b.name)),
-    ]),
-  );
+    ];
+  });
 
   constructor() {
     this.yamlLoader
@@ -60,22 +60,21 @@ export class AppService {
   /**
    * Computed: Filtered apps based on search and category
    */
-  readonly filteredApps$: Observable<SelfhostedApp[]> = combineLatest([
-    this.apps$,
-    this.searchService.searchQuery$,
-    this.categoryService.selectedCategory$,
-  ]).pipe(
-    map(([apps, query, category]) =>
-      this.searchService.filterApps(apps, query, category, query.trim() !== ''),
-    ),
-    distinctUntilChanged(),
-  );
+  readonly filteredApps = computed<SelfhostedApp[] | undefined>(() => {
+    if (!this.configService.config()) return undefined;
+    return this.searchService.filterApps(
+      this.apps(),
+      this.searchService.searchQuery(),
+      this.categoryService.selectedCategory(),
+      this.searchService.haveSearch(),
+    );
+  });
 
   /**
    * Current config value (synchronous access)
    */
   get config(): DashboardConfig | undefined {
-    return this.configService.subject.value;
+    return this.configService.config();
   }
 
   /**
@@ -83,7 +82,7 @@ export class AppService {
    * @param config - Dashboard configuration
    */
   initializeConfig(config: DashboardConfig): void {
-    this.configService.subject.next(config);
+    this.configService.fireNewSubject(config);
     this.logger.info('[AppService] Dashboard config initialized');
   }
 

--- a/src/app/core/services/bookmark.service.ts
+++ b/src/app/core/services/bookmark.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { map } from 'rxjs/operators';
+import { computed } from '@angular/core';
 
 import { ConfigService } from './config.service';
 
@@ -7,9 +7,5 @@ import { ConfigService } from './config.service';
 export class BookmarkService {
   private configService = inject(ConfigService);
 
-  readonly bookmarks$ = this.configService.config$.pipe(map((config) => config.bookmarks));
-
-  get bookmarks() {
-    return this.configService.subject.value?.bookmarks || [];
-  }
+  readonly bookmarks = computed(() => this.configService.config()?.bookmarks ?? []);
 }

--- a/src/app/core/services/category.service.spec.ts
+++ b/src/app/core/services/category.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { CategoryService } from './category.service';
 import { ConfigService } from './config.service';
@@ -14,7 +14,7 @@ import {
 
 describe('CategoryService', () => {
   let service: CategoryService;
-  let configSubject: BehaviorSubject<DashboardConfig>;
+  let configSubject: ReturnType<typeof signal<DashboardConfig | undefined>>;
 
   const createConfig = (overrides: Partial<DashboardConfig> = {}): DashboardConfig => ({
     ...DEFAULT_DASHBOARD_CONFIG,
@@ -22,7 +22,7 @@ describe('CategoryService', () => {
   });
 
   beforeEach(() => {
-    configSubject = new BehaviorSubject<DashboardConfig>(createConfig());
+    configSubject = signal<DashboardConfig | undefined>(createConfig());
 
     TestBed.configureTestingModule({
       providers: [
@@ -30,7 +30,7 @@ describe('CategoryService', () => {
         {
           provide: ConfigService,
           useValue: {
-            config$: configSubject.asObservable(),
+            config: configSubject.asReadonly(),
           },
         },
       ],
@@ -41,7 +41,7 @@ describe('CategoryService', () => {
 
   describe('categories$', () => {
     it('should prepend FAVORITES_CATEGORY as the first category when at least one app is favorited', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -65,13 +65,13 @@ describe('CategoryService', () => {
         }),
       );
 
-      const categories = await firstValueFrom(service.categories$);
+      const categories = service.categories();
       expect(categories[0]).toEqual(FAVORITES_CATEGORY);
       expect(categories.map((c) => c.id)).toEqual(['favorites', 'apps', 'media']);
     });
 
     it('should omit FAVORITES_CATEGORY when no apps are favorited', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -95,13 +95,13 @@ describe('CategoryService', () => {
         }),
       );
 
-      const categories = await firstValueFrom(service.categories$);
+      const categories = service.categories();
       expect(categories.some((c) => c.id === FAVORITES_CATEGORY.id)).toBe(false);
       expect(categories.map((c) => c.id)).toEqual(['apps', 'media']);
     });
 
     it('should place virtual categories first, followed by user categories sorted A-Z', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -128,7 +128,7 @@ describe('CategoryService', () => {
         }),
       );
 
-      const categories = await firstValueFrom(service.categories$);
+      const categories = service.categories();
       const ids = categories.map((c) => c.id);
       expect(ids[0]).toBe('favorites');
       expect(ids.indexOf('apps')).toBeLessThan(ids.indexOf('media'));
@@ -139,7 +139,7 @@ describe('CategoryService', () => {
 
   describe('selectedCategory$ fallback', () => {
     it('should auto-select the first visible category when the current selection disappears', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -169,7 +169,7 @@ describe('CategoryService', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Remove all favorites so Favorites category disappears
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -195,12 +195,12 @@ describe('CategoryService', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      const selectedId = await firstValueFrom(service.selectedCategory$);
+      const selectedId = service.selectedCategory();
       expect(selectedId).toBe('media');
     });
 
     it('should select FAVORITES_CATEGORY as first visible when showAllCategory is false and favorites exist', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -226,12 +226,12 @@ describe('CategoryService', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      const selectedId = await firstValueFrom(service.selectedCategory$);
+      const selectedId = service.selectedCategory();
       expect(selectedId).toBe(FAVORITES_CATEGORY.id);
     });
 
     it('should select the first user category when showAllCategory is false and no favorites exist', async () => {
-      configSubject.next(
+      configSubject.set(
         createConfig({
           applications: [
             {
@@ -257,7 +257,7 @@ describe('CategoryService', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      const selectedId = await firstValueFrom(service.selectedCategory$);
+      const selectedId = service.selectedCategory();
       expect(selectedId).toBe('media');
     });
   });

--- a/src/app/core/services/category.service.ts
+++ b/src/app/core/services/category.service.ts
@@ -1,6 +1,4 @@
-import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { computed, effect, inject, Injectable, signal } from '@angular/core';
 
 import {
   APP_CATEGORY,
@@ -15,34 +13,34 @@ import { ConfigService } from './config.service';
 export class CategoryService {
   private configService = inject(ConfigService);
 
-  private readonly selectedCategorySubject = new BehaviorSubject<string>(APP_CATEGORY.id);
+  private readonly selectedCategoryState = signal(APP_CATEGORY.id);
+  readonly selectedCategory = this.selectedCategoryState.asReadonly();
+  readonly categories = computed(() => {
+    const config = this.configService.config();
+    if (!config) return [];
+    const categories: Category[] = [];
 
-  readonly categories$ = this.configService.config$.pipe(
-    map((config) => {
-      const categories: Category[] = [];
+    if (config.applications.some((app) => app.favorite)) {
+      categories.push(FAVORITES_CATEGORY);
+    }
 
-      if (config.applications.some((app) => app.favorite)) {
-        categories.push(FAVORITES_CATEGORY);
-      }
+    if (config.settings.showAllCategory) {
+      categories.push(APP_CATEGORY);
+    }
 
-      if (config.settings.showAllCategory) {
-        categories.push(APP_CATEGORY);
-      }
+    if (config.settings.allowBookmarks) {
+      categories.push(BOOKMARKS_CATEGORY);
+    }
 
-      if (config.settings.allowBookmarks) {
-        categories.push(BOOKMARKS_CATEGORY);
-      }
-
-      return [...categories, ...config.categories.sort((a, b) => a.name.localeCompare(b.name))];
-    }),
-  );
-  readonly selectedCategory$ = this.selectedCategorySubject.asObservable();
+    return [...categories, ...config.categories.sort((a, b) => a.name.localeCompare(b.name))];
+  });
 
   constructor() {
-    this.categories$.subscribe((categories) => {
+    effect(() => {
+      const categories = this.categories();
       const ids = categories.map((c) => c.id);
-      if (!ids.includes(this.selectedCategorySubject.value) && categories.length > 0) {
-        this.selectedCategorySubject.next(categories[0].id);
+      if (!ids.includes(this.selectedCategory()) && categories.length > 0) {
+        this.selectedCategoryState.set(categories[0].id);
       }
     });
   }
@@ -52,6 +50,6 @@ export class CategoryService {
    * @param categoryId - Category ID
    */
   setSelectedCategory(categoryId: string): void {
-    this.selectedCategorySubject.next(categoryId);
+    this.selectedCategoryState.set(categoryId);
   }
 }

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -1,29 +1,13 @@
-import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Injectable, signal } from '@angular/core';
 
 import { DashboardConfig } from '../models/dashboard.models';
 
 @Injectable({ providedIn: 'root' })
-export class ConfigService implements OnDestroy {
-  private configSubject = new BehaviorSubject<DashboardConfig | undefined>(undefined);
-
-  destroy$: Subject<void> = new Subject<void>();
-
-  readonly config$ = this.configSubject.asObservable().pipe(
-    takeUntil(this.destroy$),
-    filter((config) => !!config),
-  );
-
-  get subject(): BehaviorSubject<DashboardConfig | undefined> {
-    return this.configSubject;
-  }
+export class ConfigService {
+  private readonly configState = signal<DashboardConfig | undefined>(undefined);
+  readonly config = this.configState.asReadonly();
 
   fireNewSubject(config: DashboardConfig): void {
-    this.configSubject.next(config);
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
+    this.configState.set(config);
   }
 }

--- a/src/app/core/services/metadata.service.ts
+++ b/src/app/core/services/metadata.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable } from '@angular/core';
-import { map } from 'rxjs';
+import { computed, inject, Injectable } from '@angular/core';
 
 import { ConfigService } from './config.service';
 
@@ -7,5 +6,5 @@ import { ConfigService } from './config.service';
 export class MetadataService {
   private configService = inject(ConfigService);
 
-  readonly metadata$ = this.configService.config$.pipe(map((config) => config.metadata));
+  readonly metadata = computed(() => this.configService.config()?.metadata);
 }

--- a/src/app/core/services/search.service.spec.ts
+++ b/src/app/core/services/search.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { SearchService } from './search.service';
 import { ConfigService } from './config.service';
@@ -34,7 +34,7 @@ describe('SearchService', () => {
         {
           provide: ConfigService,
           useValue: {
-            config$: new BehaviorSubject({}),
+            config: signal(undefined),
           },
         },
       ],

--- a/src/app/core/services/search.service.ts
+++ b/src/app/core/services/search.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, map } from 'rxjs';
+import { computed, inject, Injectable, signal } from '@angular/core';
 
 import { ConfigService } from './config.service';
 
@@ -19,15 +18,12 @@ import {
 export class SearchService {
   private configService = inject(ConfigService);
 
-  private readonly searchQuerySubject = new BehaviorSubject<string>('');
-
-  haveSearchSubject = new BehaviorSubject<boolean>(false);
-
-  readonly searchEngines$ = this.configService.config$.pipe(
-    map((config) => config.settings.searchEngines),
-    map((searchEngines) => searchEngines.map(this.getSearchEngineById)),
+  private readonly searchQueryState = signal('');
+  readonly searchQuery = this.searchQueryState.asReadonly();
+  readonly haveSearch = computed(() => this.searchQuery().trim() !== '');
+  readonly searchEngines = computed(() =>
+    (this.configService.config()?.settings.searchEngines ?? []).map(this.getSearchEngineById),
   );
-  readonly searchQuery$ = this.searchQuerySubject.asObservable();
 
   /**
    * Get search engine by ID
@@ -43,8 +39,7 @@ export class SearchService {
    * @param query - Search query string
    */
   setSearchQuery(query: string): void {
-    this.searchQuerySubject.next(query);
-    this.haveSearchSubject.next(query.trim() !== '');
+    this.searchQueryState.set(query);
   }
 
   /**

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -1,29 +1,14 @@
-import { inject, Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { computed, inject, Injectable } from '@angular/core';
 
 import { DashboardSettings, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
 
 import { ConfigService } from './config.service';
 
 @Injectable({ providedIn: 'root' })
-export class SettingsService implements OnDestroy {
+export class SettingsService {
   private configService = inject(ConfigService);
 
-  settingsSubject = new BehaviorSubject<DashboardSettings>(DEFAULT_DASHBOARD_CONFIG.settings);
-
-  destroy$: Subject<void> = new Subject<void>();
-
-  readonly settings$ = this.configService.config$.pipe(
-    takeUntil(this.destroy$),
-    map((config) => config.settings),
+  readonly settings = computed<DashboardSettings>(
+    () => this.configService.config()?.settings ?? DEFAULT_DASHBOARD_CONFIG.settings,
   );
-
-  constructor() {
-    this.settings$.subscribe((settings) => this.settingsSubject.next(settings));
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-  }
 }

--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -1,0 +1,83 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardSettings, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { SettingsService } from './settings.service';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  let settings: ReturnType<typeof signal<DashboardSettings>>;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    settings = signal(DEFAULT_DASHBOARD_CONFIG.settings);
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        ThemeService,
+        {
+          provide: SettingsService,
+          useValue: { settings: settings.asReadonly() },
+        },
+      ],
+    });
+  });
+
+  it('falls back to configured settings when localStorage cannot be read', () => {
+    settings.set({ ...DEFAULT_DASHBOARD_CONFIG.settings, theme: 'dark' });
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+
+    expect(service.getThemeMode()).toBe('dark');
+    expect(service.getCurrentTheme()).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      '[ThemeService] Failed to read theme from localStorage:',
+      expect.objectContaining({ name: 'SecurityError' }),
+    );
+  });
+
+  it('reconciles a delayed configured theme when no preference is stored', () => {
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+
+    settings.set({ ...DEFAULT_DASHBOARD_CONFIG.settings, theme: 'dark' });
+    TestBed.flushEffects();
+
+    expect(service.getThemeMode()).toBe('dark');
+    expect(service.getCurrentTheme()).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('keeps a stored preference when configured settings arrive later', () => {
+    localStorage.setItem('dashboard-theme', 'light');
+    const service = TestBed.inject(ThemeService);
+
+    settings.set({ ...DEFAULT_DASHBOARD_CONFIG.settings, theme: 'dark' });
+    TestBed.flushEffects();
+
+    expect(service.getThemeMode()).toBe('light');
+    expect(service.getCurrentTheme()).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -1,9 +1,6 @@
-import { Injectable, inject } from '@angular/core';
+import { effect, Injectable, inject } from '@angular/core';
 import { signal, computed, Signal } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { Observable, fromEvent, BehaviorSubject } from 'rxjs';
-import { startWith, map } from 'rxjs/operators';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 import { SettingsService } from './settings.service';
 
@@ -34,24 +31,7 @@ export class ThemeService {
   // Reactive state with signals
   private readonly themeModeSignal = signal<ThemeMode>('auto');
   private readonly currentThemeSignal = signal<'light' | 'dark'>('light');
-
-  private readonly settings = toSignal(this.settingsService.settings$);
-
-  themeSubject: BehaviorSubject<ThemeMode> = new BehaviorSubject<ThemeMode>(
-    this.currentThemeSignal(),
-  );
-
-  /**
-   * Observable streams for component consumption
-   */
-  readonly themeMode$: Observable<ThemeMode> = fromEvent<StorageEvent>(window, 'storage').pipe(
-    startWith({ key: this.STORAGE_KEY } as StorageEvent),
-    map(() => this.getStoredThemeMode() || 'auto'),
-  );
-
-  readonly isDark$: Observable<boolean> = this.themeMode$.pipe(
-    map((mode) => this.isDarkMode(mode)),
-  );
+  private hasUserPreference = false;
 
   // Signal-based API (preferred in Angular 21)
   readonly themeMode: Signal<ThemeMode> = this.themeModeSignal.asReadonly();
@@ -68,8 +48,22 @@ export class ThemeService {
    */
   private initializeTheme(): void {
     const storedMode = this.getStoredThemeMode();
-    this.themeModeSignal.set(storedMode);
-    this.applyTheme(storedMode);
+
+    if (storedMode) {
+      this.hasUserPreference = true;
+      this.themeModeSignal.set(storedMode);
+      this.applyTheme(storedMode);
+      return;
+    }
+
+    effect(() => {
+      const configuredMode = this.settingsService.settings().theme;
+
+      if (!this.hasUserPreference) {
+        this.themeModeSignal.set(configuredMode);
+        this.applyTheme(configuredMode);
+      }
+    });
   }
 
   /**
@@ -93,8 +87,8 @@ export class ThemeService {
    * @param mode - Theme mode to set
    */
   setThemeMode(mode: ThemeMode): void {
+    this.hasUserPreference = true;
     this.themeModeSignal.set(mode);
-    this.themeSubject.next(mode);
     this.saveThemeMode(mode);
     this.applyTheme(mode);
   }
@@ -194,12 +188,13 @@ export class ThemeService {
    * Get stored theme mode from localStorage
    * @returns Theme mode or 'auto' if not set
    */
-  private getStoredThemeMode(): ThemeMode {
-    return (
-      (localStorage.getItem(this.STORAGE_KEY) as ThemeMode) ||
-      this.settings()?.theme ||
-      this.currentThemeSignal()
-    );
+  private getStoredThemeMode(): ThemeMode | undefined {
+    try {
+      return (localStorage.getItem(this.STORAGE_KEY) as ThemeMode) || undefined;
+    } catch (error) {
+      console.warn('[ThemeService] Failed to read theme from localStorage:', error);
+      return undefined;
+    }
   }
 
   /**

--- a/src/app/shared/components/app-card/app-card.component.spec.ts
+++ b/src/app/shared/components/app-card/app-card.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { BehaviorSubject } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { AppCardComponent } from './app-card.component';
 
@@ -11,7 +11,7 @@ import { DEFAULT_DASHBOARD_CONFIG, SelfhostedApp } from '../../../core/models/da
 import { expectNoAxeViolations } from '../../../../testing/a11y';
 
 describe('AppCardComponent', () => {
-  const settingsSubject = new BehaviorSubject(DEFAULT_DASHBOARD_CONFIG.settings);
+  const settingsState = signal(DEFAULT_DASHBOARD_CONFIG.settings);
   const iconServiceMock = {
     getIconUrl: vi.fn((app: SelfhostedApp) => `https://example.com/icons/${app.id}.png`),
   };
@@ -35,7 +35,7 @@ describe('AppCardComponent', () => {
     app: SelfhostedApp = appFixture,
     settings = DEFAULT_DASHBOARD_CONFIG.settings,
   ) => {
-    settingsSubject.next(settings);
+    settingsState.set(settings);
     iconServiceMock.getIconUrl.mockClear();
 
     const view = await render(AppCardComponent, {
@@ -50,7 +50,7 @@ describe('AppCardComponent', () => {
         {
           provide: SettingsService,
           useValue: {
-            settingsSubject,
+            settings: settingsState,
           },
         },
       ],
@@ -109,7 +109,7 @@ describe('AppCardComponent', () => {
     expect(screen.getByText('Media server')).toBeInTheDocument();
     expect(screen.getByText('video')).toBeInTheDocument();
 
-    settingsSubject.next({
+    settingsState.set({
       ...DEFAULT_DASHBOARD_CONFIG.settings,
       showDescriptions: false,
       showLabels: false,

--- a/src/app/shared/components/app-card/app-card.component.ts
+++ b/src/app/shared/components/app-card/app-card.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, input, output, ChangeDetectionStrategy, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 import { SelfhostedApp } from '../../../core/models/dashboard.models';
 
@@ -19,7 +18,7 @@ import { SettingsService } from '../../../core/services/settings.service';
 })
 export class AppCardComponent {
   private readonly settingsService = inject(SettingsService);
-  private readonly settings = toSignal(this.settingsService.settingsSubject, { requireSync: true });
+  private readonly settings = this.settingsService.settings;
 
   // Inputs
   readonly app = input.required<SelfhostedApp>();

--- a/src/app/shared/components/app-categories/app-categories.component.spec.ts
+++ b/src/app/shared/components/app-categories/app-categories.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { BehaviorSubject, of } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { AppCategoriesComponent } from './app-categories.component';
 
@@ -24,16 +24,16 @@ describe('AppCategoriesComponent', () => {
     setSelectedCategory: vi.fn(),
   };
 
-  const selectedCategorySubject = new BehaviorSubject<string>('media');
-  const haveSearchSubject = new BehaviorSubject<boolean>(false);
+  const selectedCategoryState = signal('media');
+  const haveSearchState = signal(false);
 
   const setup = async ({
     selectedCategory = 'media',
     haveSearch = false,
   }: { selectedCategory?: string; haveSearch?: boolean } = {}) => {
     appServiceMock.setSelectedCategory.mockReset();
-    selectedCategorySubject.next(selectedCategory);
-    haveSearchSubject.next(haveSearch);
+    selectedCategoryState.set(selectedCategory);
+    haveSearchState.set(haveSearch);
 
     return render(AppCategoriesComponent, {
       providers: [
@@ -44,14 +44,14 @@ describe('AppCategoriesComponent', () => {
         {
           provide: CategoryService,
           useValue: {
-            categories$: of(categories),
-            selectedCategory$: selectedCategorySubject,
+            categories: signal(categories),
+            selectedCategory: selectedCategoryState,
           },
         },
         {
           provide: SearchService,
           useValue: {
-            haveSearchSubject,
+            haveSearch: haveSearchState,
           },
         },
       ],
@@ -105,13 +105,13 @@ describe('AppCategoriesComponent', () => {
     expect(categoriesNav).not.toHaveClass('opacity-50');
     expect(mediaButton).toBeEnabled();
 
-    haveSearchSubject.next(true);
+    haveSearchState.set(true);
     await view.fixture.whenStable();
 
     expect(categoriesNav).toHaveClass('opacity-50');
     expect(mediaButton).toBeDisabled();
 
-    haveSearchSubject.next(false);
+    haveSearchState.set(false);
     await view.fixture.whenStable();
 
     expect(categoriesNav).not.toHaveClass('opacity-50');
@@ -128,7 +128,7 @@ describe('AppCategoriesComponent', () => {
     expect(mediaButton).toHaveClass('bg-white/10', 'border-white/50');
     expect(appsButton).toHaveAttribute('aria-pressed', 'false');
 
-    selectedCategorySubject.next(APP_CATEGORY.id);
+    selectedCategoryState.set(APP_CATEGORY.id);
     await view.fixture.whenStable();
 
     expect(appsButton).toHaveAttribute('aria-pressed', 'true');
@@ -147,7 +147,7 @@ describe('AppCategoriesComponent', () => {
       },
     ];
 
-    selectedCategorySubject.next('favorites');
+    selectedCategoryState.set('favorites');
 
     await render(AppCategoriesComponent, {
       providers: [
@@ -158,14 +158,14 @@ describe('AppCategoriesComponent', () => {
         {
           provide: CategoryService,
           useValue: {
-            categories$: of(categoriesWithFavorites),
-            selectedCategory$: selectedCategorySubject,
+            categories: signal(categoriesWithFavorites),
+            selectedCategory: selectedCategoryState,
           },
         },
         {
           provide: SearchService,
           useValue: {
-            haveSearchSubject,
+            haveSearch: haveSearchState,
           },
         },
       ],

--- a/src/app/shared/components/app-categories/app-categories.component.ts
+++ b/src/app/shared/components/app-categories/app-categories.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 import { AppService } from '../../../core/services/app.service';
 import { CategoryService } from '../../../core/services/category.service';
@@ -18,9 +17,9 @@ export class AppCategoriesComponent {
   private readonly categoryService = inject(CategoryService);
   private readonly searchService = inject(SearchService);
 
-  readonly categories = toSignal(this.categoryService.categories$);
-  readonly selectedCategory = toSignal(this.categoryService.selectedCategory$);
-  readonly haveSearch = toSignal(this.searchService.haveSearchSubject);
+  readonly categories = this.categoryService.categories;
+  readonly selectedCategory = this.categoryService.selectedCategory;
+  readonly haveSearch = this.searchService.haveSearch;
 
   /**
    * Handle category change

--- a/src/app/shared/components/app-clock/app-clock.component.spec.ts
+++ b/src/app/shared/components/app-clock/app-clock.component.spec.ts
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/angular';
-import { BehaviorSubject } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { DEFAULT_DASHBOARD_CONFIG, DashboardSettings } from '../../../core/models/dashboard.models';
 import { SettingsService } from '../../../core/services/settings.service';
@@ -14,7 +14,7 @@ describe('AppClockComponent', () => {
   it('updates the rendered time every second under OnPush', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
-    const settingsSubject = new BehaviorSubject<DashboardSettings>({
+    const settings = signal<DashboardSettings>({
       ...DEFAULT_DASHBOARD_CONFIG.settings,
       showDate: false,
       showSeconds: true,
@@ -24,7 +24,7 @@ describe('AppClockComponent', () => {
       providers: [
         {
           provide: SettingsService,
-          useValue: { settingsSubject },
+          useValue: { settings },
         },
       ],
     });

--- a/src/app/shared/components/app-clock/app-clock.component.ts
+++ b/src/app/shared/components/app-clock/app-clock.component.ts
@@ -24,19 +24,19 @@ export class AppClockComponent implements OnInit, OnDestroy {
   currentDate = signal<number>(Date.now());
 
   get dateFormat(): string {
-    return this.settingsService.settingsSubject.value.dateFormat;
+    return this.settingsService.settings().dateFormat;
   }
 
   get dateOnBottom(): boolean {
-    return this.showDate && this.settingsService.settingsSubject.value.datePosition === 'bottom';
+    return this.showDate && this.settingsService.settings().datePosition === 'bottom';
   }
 
   get dateOnTop(): boolean {
-    return this.showDate && this.settingsService.settingsSubject.value.datePosition === 'top';
+    return this.showDate && this.settingsService.settings().datePosition === 'top';
   }
 
   get showSeconds(): boolean {
-    return this.settingsService.settingsSubject.value.showSeconds;
+    return this.settingsService.settings().showSeconds;
   }
 
   ngOnInit(): void {
@@ -50,6 +50,6 @@ export class AppClockComponent implements OnInit, OnDestroy {
   }
 
   private get showDate(): boolean {
-    return this.settingsService.settingsSubject.value.showDate;
+    return this.settingsService.settings().showDate;
   }
 }

--- a/src/app/shared/components/app-finder/app-finder.component.spec.ts
+++ b/src/app/shared/components/app-finder/app-finder.component.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { of } from 'rxjs';
+import { signal } from '@angular/core';
 
 import { AppFinderComponent } from './app-finder.component';
 
@@ -30,7 +30,7 @@ describe('AppFinderComponent', () => {
         {
           provide: SearchService,
           useValue: {
-            searchEngines$: of(searchEngines),
+            searchEngines: signal(searchEngines),
           },
         },
       ],
@@ -60,7 +60,7 @@ describe('AppFinderComponent', () => {
         {
           provide: SearchService,
           useValue: {
-            searchEngines$: of([]),
+            searchEngines: signal([]),
           },
         },
       ],

--- a/src/app/shared/components/app-finder/app-finder.component.ts
+++ b/src/app/shared/components/app-finder/app-finder.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroChevronDown,
@@ -47,12 +46,8 @@ export class AppFinderComponent {
   protected readonly selectedEngine = signal<SearchEngine | null>(null);
   protected readonly isEngineDropdownOpen = signal(false);
 
-  private readonly searchEngines = toSignal(this.searchService.searchEngines$, {
-    initialValue: [],
-  });
-
   protected readonly haveSearch = computed(() => this.searchQuery().trim() !== '');
-  protected readonly availableEngines = computed(() => this.searchEngines());
+  protected readonly availableEngines = computed(() => this.searchService.searchEngines());
   protected readonly currentEngine = computed(() => this.selectedEngine() ?? null);
 
   get inputPlaceholder(): string {

--- a/src/app/shared/components/app-header/app-header.component.spec.ts
+++ b/src/app/shared/components/app-header/app-header.component.spec.ts
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { Mock } from 'vitest';
 import { CommonModule } from '@angular/common';
 import { signal } from '@angular/core';
-import { of } from 'rxjs';
 
 import { AppHeaderComponent } from './app-header.component';
 
@@ -27,7 +26,7 @@ describe('AppHeader', () => {
         {
           provide: MetadataService,
           useValue: {
-            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+            metadata: signal(DEFAULT_DASHBOARD_CONFIG.metadata),
           },
         },
       ],

--- a/src/app/shared/components/app-header/app-header.component.ts
+++ b/src/app/shared/components/app-header/app-header.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 import { ThemeService } from '../../../core/services/theme.service';
 import { MetadataService } from '../../../core/services/metadata.service';
@@ -15,7 +14,7 @@ export class AppHeaderComponent {
   private readonly themeService = inject(ThemeService);
   private readonly metadataService = inject(MetadataService);
 
-  readonly metadata = toSignal(this.metadataService.metadata$);
+  readonly metadata = this.metadataService.metadata;
 
   readonly themeIcon = computed(() => (this.themeService.isDark() ? '🌙' : '☀️'));
   readonly themeText = computed(() => (this.themeService.isDark() ? 'Dark' : 'Light'));

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -11,7 +11,7 @@
 
   <!-- Apps grid - scrollable -->
   <div class="flex-1 overflow-y-auto px-6 md:px-8 pb-14">
-    @if (filteredApps$ | async; as apps) {
+    @if (filteredApps(); as apps) {
       @if (apps.length > 0) {
         <ul
           aria-label="Applications"
@@ -31,7 +31,7 @@
           <div class="text-6xl mb-4">🔍</div>
           <h2 class="text-2xl font-semibold text-white mb-2">No applications found</h2>
           <p class="text-white/70">
-            @if (searchQuery$ | async) {
+            @if (searchQuery()) {
               Try adjusting your search query or select a different category.
             } @else {
               Add some applications to your dashboard.yaml configuration.

--- a/src/app/views/dashboard/dashboard.component.spec.ts
+++ b/src/app/views/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/angular';
 import { signal } from '@angular/core';
-import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
 
@@ -36,15 +35,15 @@ describe('DashboardComponent', () => {
     favorite: false,
   };
 
-  const settingsSubject = new BehaviorSubject<DashboardSettings>(DEFAULT_DASHBOARD_CONFIG.settings);
-  const selectedCategorySubject = new BehaviorSubject<string>(APP_CATEGORY.id);
-  const haveSearchSubject = new BehaviorSubject<boolean>(false);
-  const themeSubject = new BehaviorSubject<'light' | 'dark' | 'auto'>('dark');
+  const settingsState = signal<DashboardSettings>(DEFAULT_DASHBOARD_CONFIG.settings);
+  const selectedCategory = signal(APP_CATEGORY.id);
+  const haveSearch = signal(false);
+  const currentTheme = signal<'light' | 'dark'>('dark');
   const isDark = signal(true);
 
   const appServiceMock = {
     appVersion: '0.2.0-test',
-    filteredApps$: of([] as SelfhostedApp[]),
+    filteredApps: signal<SelfhostedApp[] | undefined>([]),
     setSearchQuery: vi.fn(),
     setSelectedCategory: vi.fn(),
   };
@@ -65,16 +64,16 @@ describe('DashboardComponent', () => {
   };
 
   const setup = async ({
-    filteredApps$ = of([] as SelfhostedApp[]),
-    searchQuery$ = of(''),
+    filteredApps = [] as SelfhostedApp[] | null,
+    searchQuery = '',
     settings = DEFAULT_DASHBOARD_CONFIG.settings,
     isDarkMode = true,
   }: {
-    filteredApps$?: Observable<SelfhostedApp[]>;
-    searchQuery$?: Observable<string>;
+    filteredApps?: SelfhostedApp[] | null;
+    searchQuery?: string;
     settings?: DashboardSettings;
     isDarkMode?: boolean;
-  } = {}): Promise<void> => {
+  } = {}) => {
     let bgLayer = document.getElementById('app-background');
     if (!bgLayer) {
       bgLayer = document.createElement('div');
@@ -85,14 +84,14 @@ describe('DashboardComponent', () => {
     appServiceMock.setSearchQuery.mockReset();
     appServiceMock.setSelectedCategory.mockReset();
     iconServiceMock.getIconUrl.mockClear();
-    settingsSubject.next(settings);
-    haveSearchSubject.next(false);
-    selectedCategorySubject.next(APP_CATEGORY.id);
-    themeSubject.next(isDarkMode ? 'dark' : 'light');
+    settingsState.set(settings);
+    haveSearch.set(false);
+    selectedCategory.set(APP_CATEGORY.id);
+    currentTheme.set(isDarkMode ? 'dark' : 'light');
     isDark.set(isDarkMode);
-    appServiceMock.filteredApps$ = filteredApps$;
+    appServiceMock.filteredApps = signal(filteredApps ?? undefined);
 
-    await render(DashboardComponent, {
+    return render(DashboardComponent, {
       providers: [
         {
           provide: AppService,
@@ -101,38 +100,37 @@ describe('DashboardComponent', () => {
         {
           provide: SearchService,
           useValue: {
-            searchQuery$,
-            searchEngines$: of([]),
-            haveSearchSubject,
+            searchQuery: signal(searchQuery),
+            searchEngines: signal([]),
+            haveSearch,
           },
         },
         {
           provide: SettingsService,
           useValue: {
-            settings$: settingsSubject.asObservable(),
-            settingsSubject,
+            settings: settingsState,
           },
         },
         {
           provide: ThemeService,
           useValue: {
-            themeSubject,
+            currentTheme,
             isDark,
-            isDarkMode: () => themeSubject.value === 'dark',
+            isDarkMode: () => currentTheme() === 'dark',
             toggleTheme: vi.fn(),
           },
         },
         {
           provide: MetadataService,
           useValue: {
-            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+            metadata: signal(DEFAULT_DASHBOARD_CONFIG.metadata),
           },
         },
         {
           provide: CategoryService,
           useValue: {
-            categories$: of([APP_CATEGORY]),
-            selectedCategory$: selectedCategorySubject,
+            categories: signal([APP_CATEGORY]),
+            selectedCategory,
           },
         },
         {
@@ -144,10 +142,8 @@ describe('DashboardComponent', () => {
   };
 
   it('should render the loading state while applications are still pending', async () => {
-    const filteredAppsSubject = new Subject<SelfhostedApp[]>();
-
-    await setup({
-      filteredApps$: filteredAppsSubject.asObservable(),
+    const view = await setup({
+      filteredApps: null,
     });
 
     expect(screen.getByText('Loading dashboard...')).toBeInTheDocument();
@@ -170,44 +166,43 @@ describe('DashboardComponent', () => {
           provide: AppService,
           useValue: {
             ...appServiceMock,
-            filteredApps$: of([appFixture, secondAppFixture]),
+            filteredApps: signal([appFixture, secondAppFixture]),
           },
         },
         {
           provide: SearchService,
           useValue: {
-            searchQuery$: of(''),
-            searchEngines$: of([]),
-            haveSearchSubject,
+            searchQuery: signal(''),
+            searchEngines: signal([]),
+            haveSearch,
           },
         },
         {
           provide: SettingsService,
           useValue: {
-            settings$: settingsSubject.asObservable(),
-            settingsSubject,
+            settings: settingsState,
           },
         },
         {
           provide: ThemeService,
           useValue: {
-            themeSubject,
+            currentTheme,
             isDark,
-            isDarkMode: () => themeSubject.value === 'dark',
+            isDarkMode: () => currentTheme() === 'dark',
             toggleTheme: vi.fn(),
           },
         },
         {
           provide: MetadataService,
           useValue: {
-            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+            metadata: signal(DEFAULT_DASHBOARD_CONFIG.metadata),
           },
         },
         {
           provide: CategoryService,
           useValue: {
-            categories$: of([APP_CATEGORY]),
-            selectedCategory$: selectedCategorySubject,
+            categories: signal([APP_CATEGORY]),
+            selectedCategory,
           },
         },
         {
@@ -221,52 +216,49 @@ describe('DashboardComponent', () => {
   });
 
   it('should have no accessibility violations in the loading state', async () => {
-    const filteredAppsSubject = new Subject<SelfhostedApp[]>();
-
     const view = await render(DashboardComponent, {
       providers: [
         {
           provide: AppService,
           useValue: {
             ...appServiceMock,
-            filteredApps$: filteredAppsSubject.asObservable(),
+            filteredApps: signal(undefined),
           },
         },
         {
           provide: SearchService,
           useValue: {
-            searchQuery$: of(''),
-            searchEngines$: of([]),
-            haveSearchSubject,
+            searchQuery: signal(''),
+            searchEngines: signal([]),
+            haveSearch,
           },
         },
         {
           provide: SettingsService,
           useValue: {
-            settings$: settingsSubject.asObservable(),
-            settingsSubject,
+            settings: settingsState,
           },
         },
         {
           provide: ThemeService,
           useValue: {
-            themeSubject,
+            currentTheme,
             isDark,
-            isDarkMode: () => themeSubject.value === 'dark',
+            isDarkMode: () => currentTheme() === 'dark',
             toggleTheme: vi.fn(),
           },
         },
         {
           provide: MetadataService,
           useValue: {
-            metadata$: of(DEFAULT_DASHBOARD_CONFIG.metadata),
+            metadata: signal(DEFAULT_DASHBOARD_CONFIG.metadata),
           },
         },
         {
           provide: CategoryService,
           useValue: {
-            categories$: of([APP_CATEGORY]),
-            selectedCategory$: selectedCategorySubject,
+            categories: signal([APP_CATEGORY]),
+            selectedCategory,
           },
         },
         {
@@ -280,9 +272,9 @@ describe('DashboardComponent', () => {
   });
 
   it('should have no accessibility violations in the empty search state', async () => {
-    await setup({
-      filteredApps$: of([]),
-      searchQuery$: of('plex'),
+    const view = await setup({
+      filteredApps: [],
+      searchQuery: 'plex',
     });
 
     await expectNoAxeViolations(document.body);
@@ -290,8 +282,8 @@ describe('DashboardComponent', () => {
 
   it('should have no accessibility violations in the empty default state', async () => {
     await setup({
-      filteredApps$: of([]),
-      searchQuery$: of(''),
+      filteredApps: [],
+      searchQuery: '',
     });
 
     await expectNoAxeViolations(document.body);
@@ -307,7 +299,7 @@ describe('DashboardComponent', () => {
     };
 
     await setup({
-      filteredApps$: of([appFixture, secondAppFixture]),
+      filteredApps: [appFixture, secondAppFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         itemsPerRow: 5,
@@ -327,8 +319,8 @@ describe('DashboardComponent', () => {
 
   it('should render the empty state for an active search', async () => {
     await setup({
-      filteredApps$: of([]),
-      searchQuery$: of('plex'),
+      filteredApps: [],
+      searchQuery: 'plex',
     });
 
     expect(screen.getByText('No applications found')).toBeInTheDocument();
@@ -341,8 +333,8 @@ describe('DashboardComponent', () => {
 
   it('should render the empty state without a search query', async () => {
     await setup({
-      filteredApps$: of([]),
-      searchQuery$: of(''),
+      filteredApps: [],
+      searchQuery: '',
     });
 
     expect(screen.getByText('No applications found')).toBeInTheDocument();
@@ -355,7 +347,7 @@ describe('DashboardComponent', () => {
 
   it('should apply the background image that matches the current theme', async () => {
     await setup({
-      filteredApps$: of([appFixture]),
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'custom-dark.jpg',
@@ -369,7 +361,7 @@ describe('DashboardComponent', () => {
 
   it('should apply the light background image when light theme is active', async () => {
     await setup({
-      filteredApps$: of([appFixture]),
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'custom-dark.jpg',
@@ -383,7 +375,7 @@ describe('DashboardComponent', () => {
 
   it('should not prefix https background image URLs with /img/', async () => {
     await setup({
-      filteredApps$: of([appFixture]),
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'https://cdn.example.com/dark.jpg',
@@ -400,7 +392,7 @@ describe('DashboardComponent', () => {
 
   it('should not prefix http background image URLs with /img/', async () => {
     await setup({
-      filteredApps$: of([appFixture]),
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'https://cdn.example.com/dark.jpg',
@@ -416,8 +408,8 @@ describe('DashboardComponent', () => {
   });
 
   it('should update the background image when the theme changes after render', async () => {
-    await setup({
-      filteredApps$: of([appFixture]),
+    const view = await setup({
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'custom-dark.jpg',
@@ -428,14 +420,15 @@ describe('DashboardComponent', () => {
 
     expectBackgroundImageToBe('/img/custom-dark.jpg');
 
-    themeSubject.next('light');
+    currentTheme.set('light');
+    await view.fixture.whenStable();
 
     expectBackgroundImageToBe('/img/custom-light.jpg');
   });
 
   it('should update the background image when settings change after render', async () => {
-    await setup({
-      filteredApps$: of([appFixture]),
+    const view = await setup({
+      filteredApps: [appFixture],
       settings: {
         ...DEFAULT_DASHBOARD_CONFIG.settings,
         darkBackgroundImage: 'initial-dark.jpg',
@@ -446,11 +439,12 @@ describe('DashboardComponent', () => {
 
     expectBackgroundImageToBe('/img/initial-dark.jpg');
 
-    settingsSubject.next({
+    settingsState.set({
       ...DEFAULT_DASHBOARD_CONFIG.settings,
       darkBackgroundImage: 'updated-dark.jpg',
       lightBackgroundImage: 'updated-light.jpg',
     });
+    await view.fixture.whenStable();
 
     expectBackgroundImageToBe('/img/updated-dark.jpg');
   });

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
+import { Component, effect, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { combineLatest, Subject, takeUntil } from 'rxjs';
 
 import { AppService } from '../../core/services/app.service';
 import { SearchService } from '../../core/services/search.service';
@@ -31,30 +30,25 @@ import { ThemeService } from '../../core/services/theme.service';
   templateUrl: 'dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent implements OnDestroy {
+export class DashboardComponent {
   private readonly appService = inject(AppService);
   private readonly searchService = inject(SearchService);
   private readonly settingsService = inject(SettingsService);
   private readonly themeService = inject(ThemeService);
 
-  private destroy$: Subject<void> = new Subject<void>();
-
-  // Observable streams
-  readonly filteredApps$ = this.appService.filteredApps$;
-  readonly searchQuery$ = this.searchService.searchQuery$;
-  readonly settings$ = this.settingsService.settings$;
-  readonly theme$ = this.themeService.themeSubject;
+  readonly filteredApps = this.appService.filteredApps;
+  readonly searchQuery = this.searchService.searchQuery;
 
   get itemsPerRow(): number {
-    return this.settingsService.settingsSubject.value.itemsPerRow;
+    return this.settingsService.settings().itemsPerRow;
   }
 
   constructor() {
-    combineLatest([this.settings$, this.theme$])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([{ lightBackgroundImage, darkBackgroundImage }]) =>
-        this.setBackgroundImage({ lightBackgroundImage, darkBackgroundImage }),
-      );
+    effect(() => {
+      const { lightBackgroundImage, darkBackgroundImage } = this.settingsService.settings();
+      this.themeService.currentTheme();
+      this.setBackgroundImage({ lightBackgroundImage, darkBackgroundImage });
+    });
   }
 
   /**
@@ -79,9 +73,5 @@ export class DashboardComponent implements OnDestroy {
     const isImageAnUrl = selectedImage.startsWith('https') || selectedImage.startsWith('http');
 
     bgLayer.style.backgroundImage = `url(${isImageAnUrl ? '' : '/img/'}${selectedImage})`;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
   }
 }


### PR DESCRIPTION
## Linked issue

Closes #35

## Type

- [x] Bug fix

## Summary

- Use Angular signals for synchronous application and UI state while retaining RxJS at the asynchronous YAML boundary.
- Keep delayed YAML theme configuration reactive without overriding persisted or newly selected user preferences.
- Make theme initialization resilient when browser storage is unavailable.
- Document the Signals/RxJS convention and update the changelog.

## Test plan

- [x] Focused service and component tests
- [x] `npm test` (88 tests)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Used a conventional commit
- [x] Updated architecture guidance and changelog
- [x] Added no AI attribution