### PR TITLE
refactor(app-finder): extract search engine selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
 - **Production Logging Cleanup**: Replaced development-only `console.log` usage in dashboard initialization and config loading flows with a centralized logger service, while removing the dashboard click debug log from production code.
+- **Accessible Search Engine Selector**: Extracted the selector into a focused component with keyboard navigation and predictable focus-based closing, while preserving the search query when a popup is blocked.
 
 ### Performance
 

--- a/src/app/shared/components/app-finder/app-finder.component.html
+++ b/src/app/shared/components/app-finder/app-finder.component.html
@@ -1,63 +1,9 @@
-<div class="relative xl:w-4xl xl:block xl:mx-auto" (click)="onCloseDropdown()">
-  <!-- Search Engine Selector -->
-  <button
-    aria-label="Select search engine"
-    aria-haspopup="listbox"
-    class="absolute z-10 top-4.5 left-4 flex items-center gap-2 text-neutral-900 dark:text-white/70 hover:text-neutral-950 dark:hover:text-white transition-colors cursor-pointer group"
-    [attr.aria-expanded]="isEngineDropdownOpen()"
-    (click)="onToggleEngineDropdown($event)"
-  >
-    @if (currentEngine()) {
-      <ng-icon
-        class="text-lg transition-transform"
-        [class.text-white]="isEngineDropdownOpen()"
-        [name]="currentEngine()!.icon"
-      />
-    } @else {
-      <ng-icon class="text-2xl opacity-50 relative bottom-1" name="heroMagnifyingGlass" />
-    }
-  </button>
-
-  <!-- Engine Dropdown -->
-  @if (availableEngines().length > 0 && isEngineDropdownOpen()) {
-    <ul
-      aria-label="Search engines"
-      class="absolute z-20 top-full left-4 mt-2 bg-white/95 text-black backdrop-blur-md border border-white/30 rounded-2xl shadow-2xl px-1 py-2 min-w-48"
-      role="listbox"
-    >
-      @if (currentEngine()) {
-        <li
-          aria-selected="true"
-          class="px-4 py-2 cursor-pointer transition-colors hover:bg-black/5 focus-visible:outline-neutral-500! rounded-2xl flex items-center gap-2"
-          role="option"
-          tabindex="0"
-          (click)="onSelectEngine()"
-          (keydown.enter)="onSelectEngine()"
-          (keydown.space)="onSelectEngine()"
-        >
-          <ng-icon name="heroMagnifyingGlass" />
-          <span class="text-gray-700">Search on your apps</span>
-        </li>
-      }
-
-      @for (engine of availableEngines(); track engine?.id) {
-        @if (currentEngine()?.id !== engine?.id) {
-          <li
-            class="px-4 py-2 cursor-pointer transition-colors hover:bg-black/5 focus-visible:outline-neutral-500! rounded-2xl flex items-center gap-2"
-            role="option"
-            tabindex="0"
-            [attr.aria-selected]="currentEngine()?.id === engine?.id"
-            (click)="onSelectEngine(engine)"
-            (keydown.enter)="onSelectEngine(engine)"
-            (keydown.space)="onSelectEngine(engine)"
-          >
-            <ng-icon [name]="engine?.icon" />
-            <span class="text-gray-700">{{ engine?.name }}</span>
-          </li>
-        }
-      }
-    </ul>
-  }
+<div class="relative xl:w-4xl xl:block xl:mx-auto">
+  <app-search-engine-selector
+    [engines]="availableEngines()"
+    [selectedEngine]="currentEngine()"
+    (engineSelected)="onSelectEngine($event)"
+  />
 
   <input
     aria-label="Search applications"

--- a/src/app/shared/components/app-finder/app-finder.component.spec.ts
+++ b/src/app/shared/components/app-finder/app-finder.component.spec.ts
@@ -129,7 +129,7 @@ describe('AppFinderComponent', () => {
   it('should search with the selected engine on Enter and clear the query afterwards', async () => {
     const user = userEvent.setup();
     const googleEngine = DEFAULT_DASHBOARD_SEARCH_ENGINES[0];
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
 
     await setup([googleEngine]);
 
@@ -145,6 +145,32 @@ describe('AppFinderComponent', () => {
       'https://www.google.com/search?q=home%20assistant',
       '_blank',
     );
+    expect(searchInput).toHaveValue('');
+  });
+
+  it('should preserve the query when an external search is blocked and clear it after retry', async () => {
+    const user = userEvent.setup();
+    const googleEngine = DEFAULT_DASHBOARD_SEARCH_ENGINES[0];
+    const windowOpenSpy = vi
+      .spyOn(window, 'open')
+      .mockImplementationOnce(() => null)
+      .mockImplementationOnce(() => window);
+
+    await setup([googleEngine]);
+
+    await user.click(screen.getByRole('button', { name: 'Select search engine' }));
+    await user.click(screen.getByRole('option', { name: googleEngine.name }));
+
+    const searchInput = screen.getByRole('searchbox', { name: 'Search applications' });
+
+    await user.type(searchInput, 'home assistant');
+    await user.keyboard('{Enter}');
+
+    expect(searchInput).toHaveValue('home assistant');
+
+    await user.keyboard('{Enter}');
+
+    expect(windowOpenSpy).toHaveBeenCalledTimes(2);
     expect(searchInput).toHaveValue('');
   });
 

--- a/src/app/shared/components/app-finder/app-finder.component.ts
+++ b/src/app/shared/components/app-finder/app-finder.component.ts
@@ -1,38 +1,20 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import {
-  heroChevronDown,
-  heroMagnifyingGlass,
-  heroXMark,
-  heroArrowRight,
-} from '@ng-icons/heroicons/outline';
-import {
-  simpleYoutube,
-  simpleGoogle,
-  simpleDuckduckgo,
-  simpleStartpage,
-} from '@ng-icons/simple-icons';
+import { heroArrowRight, heroXMark } from '@ng-icons/heroicons/outline';
 
 import { AppService } from '../../../core/services/app.service';
 import { SearchService } from '../../../core/services/search.service';
 
 import { SearchEngine } from '../../../core/models/dashboard.models';
+import { AppSearchEngineSelectorComponent } from '../app-search-engine-selector/app-search-engine-selector.component';
 
 @Component({
   selector: 'app-finder',
-  standalone: true,
-  imports: [CommonModule, NgIcon],
+  imports: [NgIcon, AppSearchEngineSelectorComponent],
   templateUrl: 'app-finder.component.html',
   viewProviders: [
     provideIcons({
-      heroMagnifyingGlass,
       heroXMark,
-      heroChevronDown,
-      simpleYoutube,
-      simpleGoogle,
-      simpleDuckduckgo,
-      simpleStartpage,
       heroArrowRight,
     }),
   ],
@@ -44,7 +26,6 @@ export class AppFinderComponent {
 
   protected readonly searchQuery = signal('');
   protected readonly selectedEngine = signal<SearchEngine | null>(null);
-  protected readonly isEngineDropdownOpen = signal(false);
 
   protected readonly haveSearch = computed(() => this.searchQuery().trim() !== '');
   protected readonly availableEngines = computed(() => this.searchService.searchEngines());
@@ -76,8 +57,12 @@ export class AppFinderComponent {
 
     if (!query || !engine) return;
 
-    window.open(engine.searchUrl.replace('{query}', encodeURIComponent(query)), '_blank');
-    this.onHandleResetSearch();
+    const openedWindow = window.open(
+      engine.searchUrl.replace('{query}', encodeURIComponent(query)),
+      '_blank',
+    );
+
+    if (openedWindow) this.onHandleResetSearch();
   }
 
   /**
@@ -90,34 +75,12 @@ export class AppFinderComponent {
   }
 
   /**
-   * Toggle engine dropdown
-   */
-  onToggleEngineDropdown(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.isEngineDropdownOpen.update((isOpen) => !isOpen);
-  }
-
-  /**
    * Select a search engine
    */
-  onSelectEngine(engine?: SearchEngine): void {
+  onSelectEngine(engine: SearchEngine | null): void {
     this.onHandleResetSearch();
 
-    if (!engine) {
-      this.selectedEngine.set(null);
-    } else {
-      this.selectedEngine.set(engine);
-    }
-
-    this.isEngineDropdownOpen.set(false);
-  }
-
-  /**
-   * Close dropdown
-   */
-  onCloseDropdown(): void {
-    this.isEngineDropdownOpen.set(false);
+    this.selectedEngine.set(engine);
   }
 
   /**

--- a/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.html
+++ b/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.html
@@ -1,0 +1,61 @@
+<div class="app-search-engine-selector" (click)="close()">
+  <button
+    #trigger
+    aria-label="Select search engine"
+    aria-haspopup="listbox"
+    class="absolute z-10 top-4.5 left-4 flex items-center gap-2 text-neutral-900 dark:text-white/70 hover:text-neutral-950 dark:hover:text-white transition-colors cursor-pointer group"
+    [attr.aria-expanded]="isOpen()"
+    [disabled]="validEngines().length === 0"
+    (click)="toggle($event)"
+    (keydown)="onTriggerKeydown($event)"
+  >
+    @if (selectedEngine(); as engine) {
+      <ng-icon
+        class="text-lg transition-transform"
+        [class.text-white]="isOpen()"
+        [name]="engine.icon"
+      />
+    } @else {
+      <ng-icon class="text-2xl opacity-50 relative bottom-1" name="heroMagnifyingGlass" />
+    }
+  </button>
+
+  @if (engines().length > 0 && isOpen()) {
+    <ul
+      aria-label="Search engines"
+      class="absolute z-20 top-full left-4 mt-2 bg-white/95 text-black backdrop-blur-md border border-white/30 rounded-2xl shadow-2xl px-1 py-2 min-w-48"
+      role="listbox"
+      (keydown)="onListboxKeydown($event)"
+    >
+      <li
+        #option
+        class="px-4 py-2 cursor-pointer transition-colors hover:bg-black/5 focus-visible:outline-neutral-500! rounded-2xl flex items-center gap-2"
+        role="option"
+        [attr.aria-selected]="selectedEngine() === null"
+        [tabindex]="activeIndex() === 0 ? 0 : -1"
+        (click)="select(null)"
+        (keydown.enter)="select(null, $event)"
+        (keydown.space)="select(null, $event)"
+      >
+        <ng-icon name="heroMagnifyingGlass" />
+        <span class="text-gray-700">Search on your apps</span>
+      </li>
+
+      @for (engine of validEngines(); track engine.id; let index = $index) {
+        <li
+          #option
+          class="px-4 py-2 cursor-pointer transition-colors hover:bg-black/5 focus-visible:outline-neutral-500! rounded-2xl flex items-center gap-2"
+          role="option"
+          [attr.aria-selected]="selectedEngine()?.id === engine.id"
+          [tabindex]="activeIndex() === index + 1 ? 0 : -1"
+          (click)="select(engine)"
+          (keydown.enter)="select(engine, $event)"
+          (keydown.space)="select(engine, $event)"
+        >
+          <ng-icon [name]="engine.icon" />
+          <span class="text-gray-700">{{ engine.name }}</span>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.spec.ts
+++ b/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.spec.ts
@@ -1,0 +1,187 @@
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { DEFAULT_DASHBOARD_SEARCH_ENGINES } from '../../../core/models/dashboard.models';
+import { expectNoAxeViolations } from '../../../../testing/a11y';
+import { AppSearchEngineSelectorComponent } from './app-search-engine-selector.component';
+
+describe('AppSearchEngineSelectorComponent', () => {
+  const googleEngine = DEFAULT_DASHBOARD_SEARCH_ENGINES[0];
+  const duckDuckGoEngine = DEFAULT_DASHBOARD_SEARCH_ENGINES[1];
+
+  it('should disable the trigger when no engine options are available', async () => {
+    const user = userEvent.setup();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [] },
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Select search engine' });
+
+    expect(trigger).toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('listbox', { name: 'Search engines' })).not.toBeInTheDocument();
+  });
+
+  it('should expose available engines and emit the selected engine', async () => {
+    const user = userEvent.setup();
+    const engineSelected = vi.fn();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine] },
+      on: { engineSelected },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Select search engine' }));
+    await user.click(screen.getByRole('option', { name: googleEngine.name }));
+
+    expect(engineSelected).toHaveBeenCalledWith(googleEngine);
+    expect(screen.queryByRole('listbox', { name: 'Search engines' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select search engine' })).toHaveFocus();
+  });
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('should emit local search selection with %s and restore trigger focus', async (_, key) => {
+    const user = userEvent.setup();
+    const engineSelected = vi.fn();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine], selectedEngine: googleEngine },
+      on: { engineSelected },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Select search engine' }));
+    await user.keyboard('{Home}');
+    await user.keyboard(key);
+
+    expect(engineSelected).toHaveBeenCalledWith(null);
+    expect(screen.queryByRole('listbox', { name: 'Search engines' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select search engine' })).toHaveFocus();
+  });
+
+  it('should expose the actual selected option to assistive technology', async () => {
+    const user = userEvent.setup();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: {
+        engines: [googleEngine, duckDuckGoEngine],
+        selectedEngine: googleEngine,
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Select search engine' }));
+
+    expect(screen.getByRole('option', { name: 'Search on your apps' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    expect(screen.getByRole('option', { name: googleEngine.name, selected: true })).toHaveFocus();
+    expect(screen.getByRole('option', { name: duckDuckGoEngine.name })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('should navigate options with Arrow keys, Home, and End', async () => {
+    const user = userEvent.setup();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine, duckDuckGoEngine] },
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Select search engine' });
+    trigger.focus();
+    await user.keyboard('{ArrowDown}');
+
+    const localOption = screen.getByRole('option', { name: 'Search on your apps' });
+    const googleOption = screen.getByRole('option', { name: googleEngine.name });
+    const duckDuckGoOption = screen.getByRole('option', { name: duckDuckGoEngine.name });
+
+    expect(localOption).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(googleOption).toHaveFocus();
+
+    await user.keyboard('{End}');
+    expect(duckDuckGoOption).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(localOption).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(duckDuckGoOption).toHaveFocus();
+  });
+
+  it('should remain open when focus moves between options', async () => {
+    const user = userEvent.setup();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine, duckDuckGoEngine] },
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Select search engine' });
+    trigger.focus();
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowDown}');
+
+    expect(screen.getByRole('option', { name: googleEngine.name })).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('listbox', { name: 'Search engines' })).toBeInTheDocument();
+  });
+
+  it('should close when Tab moves focus outside the selector', async () => {
+    const user = userEvent.setup();
+    const externalButton = document.createElement('button');
+    externalButton.textContent = 'External control';
+
+    try {
+      await render(AppSearchEngineSelectorComponent, {
+        inputs: { engines: [googleEngine] },
+      });
+      document.body.append(externalButton);
+
+      const trigger = screen.getByRole('button', { name: 'Select search engine' });
+      trigger.focus();
+      await user.keyboard('{ArrowDown}');
+      await user.tab();
+
+      expect(externalButton).toHaveFocus();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('listbox', { name: 'Search engines' })).not.toBeInTheDocument();
+    } finally {
+      externalButton.remove();
+    }
+  });
+
+  it('should close with Escape and restore focus to the trigger', async () => {
+    const user = userEvent.setup();
+
+    await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine] },
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Select search engine' });
+    await user.click(trigger);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox', { name: 'Search engines' })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should have no accessibility violations when open', async () => {
+    const user = userEvent.setup();
+    const view = await render(AppSearchEngineSelectorComponent, {
+      inputs: { engines: [googleEngine] },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Select search engine' }));
+
+    await expectNoAxeViolations(view.container);
+  });
+});

--- a/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.ts
+++ b/src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.ts
@@ -1,0 +1,149 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  input,
+  output,
+  signal,
+  viewChild,
+  viewChildren,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
+import {
+  simpleDuckduckgo,
+  simpleGoogle,
+  simpleStartpage,
+  simpleYoutube,
+} from '@ng-icons/simple-icons';
+
+import { SearchEngine } from '../../../core/models/dashboard.models';
+
+@Component({
+  selector: 'app-search-engine-selector',
+  imports: [NgIcon],
+  templateUrl: 'app-search-engine-selector.component.html',
+  host: {
+    '(focusout)': 'onFocusOut($event)',
+  },
+  viewProviders: [
+    provideIcons({
+      heroChevronDown,
+      heroMagnifyingGlass,
+      simpleDuckduckgo,
+      simpleGoogle,
+      simpleStartpage,
+      simpleYoutube,
+    }),
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppSearchEngineSelectorComponent {
+  readonly engines = input.required<(SearchEngine | undefined)[]>();
+  readonly selectedEngine = input<SearchEngine | null>(null);
+  readonly engineSelected = output<SearchEngine | null>();
+
+  protected readonly isOpen = signal(false);
+  protected readonly validEngines = computed(() =>
+    this.engines().filter((engine): engine is SearchEngine => engine !== undefined),
+  );
+  protected readonly activeIndex = signal(0);
+
+  private readonly trigger = viewChild.required<ElementRef<HTMLButtonElement>>('trigger');
+  private readonly options = viewChildren<ElementRef<HTMLElement>>('option');
+
+  protected toggle(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (this.validEngines().length === 0) return;
+
+    if (this.isOpen()) {
+      this.close();
+      return;
+    }
+
+    this.open();
+  }
+
+  protected select(engine: SearchEngine | null, event?: Event): void {
+    event?.preventDefault();
+    this.engineSelected.emit(engine);
+    this.isOpen.set(false);
+    queueMicrotask(() => this.trigger().nativeElement.focus());
+  }
+
+  protected close(): void {
+    this.isOpen.set(false);
+  }
+
+  protected onFocusOut(event: FocusEvent): void {
+    const host = event.currentTarget as HTMLElement;
+    const nextTarget = event.relatedTarget;
+
+    if (!(nextTarget instanceof Node) || !host.contains(nextTarget)) this.close();
+  }
+
+  protected onTriggerKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+
+    event.preventDefault();
+
+    if (this.validEngines().length === 0) return;
+
+    if (!this.isOpen()) {
+      this.open(event.key === 'ArrowUp' ? this.validEngines().length : 0);
+      return;
+    }
+
+    this.moveFocus(event.key === 'ArrowDown' ? 1 : -1);
+  }
+
+  protected onListboxKeydown(event: KeyboardEvent): void {
+    const lastIndex = this.validEngines().length;
+    let nextIndex: number | undefined;
+
+    if (event.key === 'ArrowDown') nextIndex = (this.activeIndex() + 1) % (lastIndex + 1);
+    if (event.key === 'ArrowUp') nextIndex = (this.activeIndex() + lastIndex) % (lastIndex + 1);
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = lastIndex;
+
+    if (nextIndex !== undefined) {
+      event.preventDefault();
+      this.focusOption(nextIndex);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      this.trigger().nativeElement.focus();
+    }
+  }
+
+  private open(index = this.selectedOptionIndex()): void {
+    this.activeIndex.set(index);
+    this.isOpen.set(true);
+    queueMicrotask(() => this.focusOption(index));
+  }
+
+  private moveFocus(offset: number): void {
+    const optionCount = this.validEngines().length + 1;
+    this.focusOption((this.activeIndex() + offset + optionCount) % optionCount);
+  }
+
+  private focusOption(index: number): void {
+    this.activeIndex.set(index);
+    this.options()[index]?.nativeElement.focus();
+  }
+
+  private selectedOptionIndex(): number {
+    const selectedId = this.selectedEngine()?.id;
+
+    if (!selectedId) return 0;
+
+    const engineIndex = this.validEngines().findIndex(({ id }) => id === selectedId);
+    return engineIndex === -1 ? 0 : engineIndex + 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Extract the search-engine selector into a focused presentational component.
- Add accessible listbox semantics, keyboard navigation, and deterministic focus management.
- Preserve external-search queries when popup creation is blocked.

## Changes

| Area | Change |
|---|---|
| `app-finder` | Retains search state and dispatch responsibilities. |
| `app-search-engine-selector` | Adds the extracted selector with accessible keyboard and focus behavior. |
| Tests | Covers selection, ARIA state, keyboard navigation, focus transitions, empty engines, and popup recovery. |
| `CHANGELOG.md` | Documents the refactor and resilience behavior. |

## Test plan

- [x] Focused component tests: 27/27 passed
- [x] Full test suite: 99/99 passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Review notes

- Maintainer-approved `size:exception`: 551 changed lines form one cohesive refactor and test unit.
- Full 4R review completed with an approved content-bound receipt.
- Maintainer explicitly authorized PR creation after the pre-PR receipt was invalidated by the isolated-worktree publication-boundary limitation; repository and candidate tree hashes remained unchanged.
- Runtime browser harness: N/A; DOM, keyboard, focus, popup recovery, and AXE behavior are covered by Angular tests.

## Checklist

- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit used
- [x] Documentation updated
- [x] No AI attribution or co-author trailers

Closes #36