### PR TITLE
test(core): cover theme and yaml boundaries

### DIFF
--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -8,23 +8,42 @@ import { ThemeService } from './theme.service';
 
 describe('ThemeService', () => {
   let settings: ReturnType<typeof signal<DashboardSettings>>;
+  let mediaQuery: MediaQueryList;
+  let systemThemeChange: ((event: MediaQueryListEvent) => void) | undefined;
+  let originalMatchMediaDescriptor: PropertyDescriptor | undefined;
 
   afterEach(() => {
+    if (originalMatchMediaDescriptor) {
+      Object.defineProperty(window, 'matchMedia', originalMatchMediaDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'matchMedia');
+    }
+    document.documentElement.removeAttribute('data-theme');
     vi.restoreAllMocks();
   });
 
   beforeEach(() => {
+    originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia');
     localStorage.clear();
     document.documentElement.classList.remove('dark');
+    document.documentElement.removeAttribute('data-theme');
     settings = signal(DEFAULT_DASHBOARD_CONFIG.settings);
 
+    mediaQuery = {
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: vi.fn((_type, listener) => {
+        systemThemeChange = listener as (event: MediaQueryListEvent) => void;
+      }),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
-      value: vi.fn().mockReturnValue({
-        matches: false,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }),
+      value: vi.fn(() => mediaQuery),
     });
 
     TestBed.configureTestingModule({
@@ -79,5 +98,83 @@ describe('ThemeService', () => {
     expect(service.getThemeMode()).toBe('light');
     expect(service.getCurrentTheme()).toBe('light');
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('sets, persists, and exposes explicit theme state', () => {
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+
+    service.setThemeMode('dark');
+
+    expect(service.themeMode()).toBe('dark');
+    expect(service.currentTheme()).toBe('dark');
+    expect(service.isDark()).toBe(true);
+    expect(service.getThemeMode()).toBe('dark');
+    expect(service.getCurrentTheme()).toBe('dark');
+    expect(service.isDarkMode()).toBe(true);
+    expect(localStorage.getItem('dashboard-theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('toggles explicit and resolved auto themes', () => {
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+
+    service.setThemeMode('light');
+    service.toggleTheme();
+    expect(service.getThemeMode()).toBe('dark');
+
+    service.resetTheme();
+    service.toggleTheme();
+    expect(service.getThemeMode()).toBe('dark');
+  });
+
+  it('resolves auto mode and reacts to system changes only while auto is active', () => {
+    Object.defineProperty(mediaQuery, 'matches', { configurable: true, value: true });
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+
+    service.resetTheme();
+    expect(service.getSystemPreference()).toBe('dark');
+    expect(service.getCurrentTheme()).toBe('dark');
+
+    systemThemeChange?.({ matches: false } as MediaQueryListEvent);
+    expect(service.getCurrentTheme()).toBe('light');
+
+    service.setThemeMode('dark');
+    systemThemeChange?.({ matches: false } as MediaQueryListEvent);
+    expect(service.getCurrentTheme()).toBe('dark');
+  });
+
+  it('keeps applying a theme when persistence fails', () => {
+    const service = TestBed.inject(ThemeService);
+    TestBed.flushEffects();
+    const failure = new DOMException('Quota exceeded', 'QuotaExceededError');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw failure;
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    service.setThemeMode('dark');
+
+    expect(service.getCurrentTheme()).toBe('dark');
+    expect(warn).toHaveBeenCalledWith(
+      '[ThemeService] Failed to save theme to localStorage:',
+      failure,
+    );
+  });
+
+  it('watches system changes and removes the exact listener during cleanup', () => {
+    const service = TestBed.inject(ThemeService);
+    const callback = vi.fn();
+    const cleanup = service.watchSystemTheme(callback);
+    const listener = systemThemeChange;
+
+    listener?.({ matches: true } as MediaQueryListEvent);
+    cleanup();
+
+    expect(callback).toHaveBeenCalledWith('dark');
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener);
   });
 });

--- a/src/app/core/services/yaml-loader.service.spec.ts
+++ b/src/app/core/services/yaml-loader.service.spec.ts
@@ -99,4 +99,50 @@ describe('YamlLoaderService', () => {
     expect(logger.warn).toHaveBeenCalledWith('[YamlLoader] Falling back to default configuration');
     expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
   });
+
+  it('falls back when parsing loaded YAML fails', async () => {
+    const parseError = new Error('invalid dashboard config');
+    httpClient.get.mockReturnValue(of('invalid-yaml'));
+    yamlParser.parseYamlOrThrow.mockImplementation(() => {
+      throw parseError;
+    });
+
+    await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(
+      DEFAULT_DASHBOARD_CONFIG,
+    );
+
+    expect(yamlParser.parseYamlOrThrow).toHaveBeenCalledWith('invalid-yaml');
+    expect(logger.error).toHaveBeenCalledWith(
+      '[YamlLoader] Failed to load dashboard config:',
+      parseError,
+    );
+    expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
+  });
+
+  it('reports whether the config resource exists', async () => {
+    httpClient.head.mockReturnValueOnce(of(undefined));
+    await expect(firstValueFrom(service.configExists())).resolves.toBe(true);
+
+    httpClient.head.mockReturnValueOnce(throwError(() => new Error('not found')));
+    await expect(firstValueFrom(service.configExists())).resolves.toBe(false);
+
+    expect(httpClient.head).toHaveBeenCalledTimes(2);
+    expect(httpClient.head).toHaveBeenCalledWith('/config/dashboard.yaml');
+  });
+
+  it('uses the outer fallback if the delegated load unexpectedly errors', async () => {
+    const outerError = new Error('unexpected outer failure');
+    vi.spyOn(service, 'loadDashboardConfig').mockReturnValue(throwError(() => outerError));
+
+    await expect(firstValueFrom(service.loadDashboardConfigWithFallback())).resolves.toEqual(
+      DEFAULT_DASHBOARD_CONFIG,
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[YamlLoader] All attempts failed, using default config:',
+      outerError,
+    );
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
+  });
 });

--- a/src/app/core/services/yaml-parser.service.spec.ts
+++ b/src/app/core/services/yaml-parser.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
-import { YamlParserService } from './yaml-parser.service';
+import { DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { ParseResult, YamlParserService } from './yaml-parser.service';
 
 describe('YamlParserService', () => {
   let service: YamlParserService;
@@ -14,6 +16,39 @@ describe('YamlParserService', () => {
   });
 
   describe('parseYaml', () => {
+    it.each(['', 'null', 'plain text'])(
+      'rejects empty or non-object YAML content: %j',
+      (yamlContent) => {
+        const result = service.parseYaml(yamlContent);
+
+        expect(result.success).toBe(false);
+        expect(result.errors?.[0]).toEqual({
+          path: [],
+          message: 'YAML content is empty or invalid',
+        });
+      },
+    );
+
+    it('reports malformed YAML without throwing', () => {
+      const result = service.parseYaml('metadata: [unterminated');
+
+      expect(result.success).toBe(false);
+      expect(result.errors?.[0]?.path).toEqual([]);
+      expect(result.errors?.[0]?.message).toContain('unexpected end of the stream');
+    });
+
+    it('returns schema validation paths, messages, and codes', () => {
+      const result = service.parseYaml('metadata: {}');
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ['metadata', 'title'], code: 'invalid_type' }),
+          expect.objectContaining({ path: ['applications'], code: 'invalid_type' }),
+        ]),
+      );
+    });
+
     it('should default favorite to false when not provided in YAML', () => {
       const yamlWithoutFavorite = `
 metadata:
@@ -104,5 +139,41 @@ settings:
       expect(result.success).toBe(true);
       expect(result.data!.applications[0].favorite).toBe(true);
     });
+  });
+
+  it('throws a formatted validation error from parseYamlOrThrow', () => {
+    expect(() => service.parseYamlOrThrow('metadata: {}')).toThrow(
+      /Failed to parse YAML:\nmetadata\.title:/,
+    );
+  });
+
+  it('reports validity through the same parse contract', () => {
+    expect(service.isValidYaml('metadata: {}')).toBe(false);
+    expect(service.isValidYaml('metadata: [unterminated')).toBe(false);
+  });
+
+  it('returns independent default configuration clones', () => {
+    const first = service.getDefaultConfig();
+    const second = service.getDefaultConfig();
+
+    first.metadata.title = 'Changed';
+    first.categories.push({ id: 'extra', name: 'Extra' });
+
+    expect(second).toEqual(DEFAULT_DASHBOARD_CONFIG);
+    expect(second).not.toBe(first);
+    expect(second.metadata).not.toBe(first.metadata);
+  });
+
+  it('formats successful, detailed, and missing errors', () => {
+    expect(service.formatErrorMessage({ success: true })).toBe('No errors');
+    expect(
+      service.formatErrorMessage({
+        success: false,
+        errors: [{ path: ['settings', 'theme'], message: 'Invalid option', code: 'invalid_value' }],
+      }),
+    ).toBe('YAML Validation Failed:\n  - settings.theme: Invalid option (invalid_value)');
+    expect(service.formatErrorMessage({ success: false } as ParseResult)).toBe(
+      'YAML Validation Failed:\n  - Unknown error',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Expand ThemeService coverage across state changes, persistence failures, and system-theme listeners
- Cover YAML parser failures, validation, defaults, cloning, and error formatting
- Exercise YAML loader parser/HTTP fallbacks and resource existence checks

## Changes

| File | Change |
|------|--------|
| `src/app/core/services/theme.service.spec.ts` | Adds deterministic theme state, storage, media-query, and cleanup coverage |
| `src/app/core/services/yaml-parser.service.spec.ts` | Covers malformed input, schema errors, defaults, cloning, and formatting |
| `src/app/core/services/yaml-loader.service.spec.ts` | Covers parser and HTTP fallback boundaries plus `configExists` |

## Test plan

- [x] Focused Theme/YAML suite — 24/24 passed
- [x] Full suite — 128/128 passed
- [x] Prettier and ESLint checks passed
- [x] `git diff --check` passed

## Chain context

```text
✅ PR 1: IconService behavior coverage (#51)
📍 PR 2: Theme and YAML boundary coverage
   PR 3: Signal-state service coverage
   PR 4: Coverage threshold and CI artifacts
```

**Start state:** Theme and YAML services lacked important failure, state-transition, and cleanup coverage.
**End state:** Their public boundaries have deterministic behavior tests with explicit state cleanup.
**Dependency:** PR #51, already merged into `develop`.
**Follow-up:** Signal-state services, followed by the measurable coverage gate and CI artifact.
**Out of scope:** Production behavior changes and retry implementation.
**Rollback:** Revert the three modified service spec files.

Closes #38