### PR TITLE
test(core): cover signal state services

### DIFF
--- a/src/app/core/services/app.service.spec.ts
+++ b/src/app/core/services/app.service.spec.ts
@@ -65,6 +65,23 @@ describe('AppService', () => {
   });
 
   describe('apps$', () => {
+    it('publishes configured applications without bookmarks when bookmarks are disabled', () => {
+      const app = {
+        id: 'plex',
+        name: 'Plex',
+        description: '',
+        url: 'https://plex.example.com',
+        icon: { type: 'name' as const, value: 'plex' },
+        category: 'media',
+        openNewTab: true,
+        tags: [],
+        favorite: false,
+      };
+      configState.set(createConfig({ applications: [app] }));
+
+      expect(service.apps()).toEqual([app]);
+      expect(service.config).toBe(configState());
+    });
     it('should assign favorite: false to bookmarks when allowBookmarks is true', async () => {
       const bookmarkServiceMock = TestBed.inject(BookmarkService);
       (
@@ -107,6 +124,45 @@ describe('AppService', () => {
       expect(apps[0].favorite).toBe(false);
       expect(apps[0].category).toBe(BOOKMARKS_CATEGORY.id);
     });
+  });
+
+  it('delegates search and category setters', () => {
+    const searchSpy = vi.spyOn(searchService, 'setSearchQuery');
+    const categorySpy = vi.spyOn(categoryService, 'setSelectedCategory');
+
+    service.setSearchQuery('plex');
+    service.setSelectedCategory('media');
+
+    expect(searchSpy).toHaveBeenCalledWith('plex');
+    expect(categorySpy).toHaveBeenCalledWith('media');
+  });
+
+  it('delegates filtering with the current app, query, category, and search state', () => {
+    const filterSpy = vi.spyOn(searchService, 'filterApps').mockReturnValue([]);
+    searchService.setSearchQuery('plex');
+    categoryService.setSelectedCategory('media');
+
+    expect(service.filteredApps()).toEqual([]);
+    expect(filterSpy).toHaveBeenCalledWith(service.apps(), 'plex', 'media', true);
+  });
+
+  it('finds configured apps by id and returns undefined for missing ids', () => {
+    const app = {
+      id: 'plex',
+      name: 'Plex',
+      description: '',
+      url: 'https://plex.example.com',
+      icon: { type: 'name' as const, value: 'plex' },
+      category: 'media',
+      openNewTab: true,
+      tags: [],
+      favorite: false,
+    };
+    configState.set(createConfig({ applications: [app] }));
+
+    expect(service.getAppById('plex')).toBe(app);
+    expect(service.getAppById('missing')).toBeUndefined();
+    expect(service.getAppsByCategory('media')).toEqual([app]);
   });
 
   describe('getAppsByCategory', () => {

--- a/src/app/core/services/bookmark.service.spec.ts
+++ b/src/app/core/services/bookmark.service.spec.ts
@@ -1,0 +1,32 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardConfig, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { BookmarkService } from './bookmark.service';
+import { ConfigService } from './config.service';
+
+describe('BookmarkService', () => {
+  it('projects bookmarks from config and reacts to config changes', () => {
+    const config = signal<DashboardConfig | undefined>(undefined);
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConfigService, useValue: { config } }],
+    });
+    const service = TestBed.inject(BookmarkService);
+
+    expect(service.bookmarks()).toEqual([]);
+
+    const bookmark = {
+      id: 'docs',
+      name: 'Docs',
+      description: 'Reference',
+      url: 'https://docs.example.com',
+      icon: { type: 'name' as const, value: 'docs' },
+      openNewTab: true,
+      tags: ['reference'],
+    };
+    config.set({ ...DEFAULT_DASHBOARD_CONFIG, bookmarks: [bookmark] });
+
+    expect(service.bookmarks()).toEqual([bookmark]);
+  });
+});

--- a/src/app/core/services/category.service.spec.ts
+++ b/src/app/core/services/category.service.spec.ts
@@ -40,6 +40,26 @@ describe('CategoryService', () => {
   });
 
   describe('categories$', () => {
+    it('publishes no categories before config is available', () => {
+      configSubject.set(undefined);
+
+      expect(service.categories()).toEqual([]);
+    });
+
+    it('publishes bookmarks first when it is the only enabled virtual category', () => {
+      configSubject.set(
+        createConfig({
+          categories: [],
+          settings: {
+            ...DEFAULT_DASHBOARD_CONFIG.settings,
+            showAllCategory: false,
+            allowBookmarks: true,
+          },
+        }),
+      );
+
+      expect(service.categories()).toEqual([BOOKMARKS_CATEGORY]);
+    });
     it('should prepend FAVORITES_CATEGORY as the first category when at least one app is favorited', async () => {
       configSubject.set(
         createConfig({
@@ -138,6 +158,11 @@ describe('CategoryService', () => {
   });
 
   describe('selectedCategory$ fallback', () => {
+    it('publishes direct selections while they remain valid', () => {
+      service.setSelectedCategory(APP_CATEGORY.id);
+
+      expect(service.selectedCategory()).toBe(APP_CATEGORY.id);
+    });
     it('should auto-select the first visible category when the current selection disappears', async () => {
       configSubject.set(
         createConfig({

--- a/src/app/core/services/config.service.spec.ts
+++ b/src/app/core/services/config.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { ConfigService } from './config.service';
+
+describe('ConfigService', () => {
+  it('publishes undefined until a config is provided and reacts to updates', () => {
+    const service = TestBed.inject(ConfigService);
+
+    expect(service.config()).toBeUndefined();
+
+    const config = { ...DEFAULT_DASHBOARD_CONFIG };
+    service.fireNewSubject(config);
+
+    expect(service.config()).toBe(config);
+  });
+});

--- a/src/app/core/services/metadata.service.spec.ts
+++ b/src/app/core/services/metadata.service.spec.ts
@@ -1,0 +1,24 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardConfig, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { ConfigService } from './config.service';
+import { MetadataService } from './metadata.service';
+
+describe('MetadataService', () => {
+  it('projects metadata and reacts when config becomes available', () => {
+    const config = signal<DashboardConfig | undefined>(undefined);
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConfigService, useValue: { config } }],
+    });
+    const service = TestBed.inject(MetadataService);
+
+    expect(service.metadata()).toBeUndefined();
+
+    const metadata = { title: 'Home', description: 'Services' };
+    config.set({ ...DEFAULT_DASHBOARD_CONFIG, metadata });
+
+    expect(service.metadata()).toBe(metadata);
+  });
+});

--- a/src/app/core/services/search.service.spec.ts
+++ b/src/app/core/services/search.service.spec.ts
@@ -7,12 +7,15 @@ import { ConfigService } from './config.service';
 import {
   APP_CATEGORY,
   BOOKMARKS_CATEGORY,
+  DashboardConfig,
+  DEFAULT_DASHBOARD_CONFIG,
   FAVORITES_CATEGORY,
   SelfhostedApp,
 } from '../models/dashboard.models';
 
 describe('SearchService', () => {
   let service: SearchService;
+  let configState: ReturnType<typeof signal<DashboardConfig | undefined>>;
 
   const createApp = (overrides: Partial<SelfhostedApp> = {}): SelfhostedApp => ({
     id: 'test',
@@ -28,13 +31,14 @@ describe('SearchService', () => {
   });
 
   beforeEach(() => {
+    configState = signal<DashboardConfig | undefined>(undefined);
     TestBed.configureTestingModule({
       providers: [
         SearchService,
         {
           provide: ConfigService,
           useValue: {
-            config: signal(undefined),
+            config: configState.asReadonly(),
           },
         },
       ],
@@ -43,7 +47,59 @@ describe('SearchService', () => {
     service = TestBed.inject(SearchService);
   });
 
+  it('publishes query state and derives whether a meaningful search exists', () => {
+    expect(service.searchQuery()).toBe('');
+    expect(service.haveSearch()).toBe(false);
+
+    service.setSearchQuery('  Plex  ');
+    expect(service.searchQuery()).toBe('  Plex  ');
+    expect(service.haveSearch()).toBe(true);
+
+    service.setSearchQuery('   ');
+    expect(service.haveSearch()).toBe(false);
+  });
+
+  it('projects configured search engines and preserves unknown entries as undefined', () => {
+    expect(service.searchEngines()).toEqual([]);
+
+    configState.set({
+      ...DEFAULT_DASHBOARD_CONFIG,
+      settings: {
+        ...DEFAULT_DASHBOARD_CONFIG.settings,
+        searchEngines: ['google', 'youtube'],
+      },
+    });
+
+    expect(service.searchEngines().map((engine) => engine?.id)).toEqual(['google', 'youtube']);
+    expect(service.getSearchEngineById('missing')).toBeUndefined();
+  });
+
   describe('filterApps', () => {
+    it('filters app and bookmark categories without search text', () => {
+      const apps = [
+        createApp({ id: 'app', category: 'media' }),
+        createApp({ id: 'bookmark', category: BOOKMARKS_CATEGORY.id }),
+      ];
+
+      expect(service.filterApps(apps, '  ', APP_CATEGORY.id).map(({ id }) => id)).toEqual(['app']);
+      expect(service.filterApps(apps, '', BOOKMARKS_CATEGORY.id).map(({ id }) => id)).toEqual([
+        'bookmark',
+      ]);
+    });
+
+    it('matches name, description, and tags case-insensitively', () => {
+      const apps = [
+        createApp({ id: 'name', name: 'PLEX Server' }),
+        createApp({ id: 'description', name: 'Other', description: 'Media manager' }),
+        createApp({ id: 'tag', name: 'Third', description: '', tags: ['STREAMING'] }),
+      ];
+
+      expect(service.filterApps(apps, 'plex', 'media').map(({ id }) => id)).toEqual(['name']);
+      expect(service.filterApps(apps, 'MANAGER', 'media').map(({ id }) => id)).toEqual([
+        'description',
+      ]);
+      expect(service.filterApps(apps, 'stream', 'media').map(({ id }) => id)).toEqual(['tag']);
+    });
     it('should return only favorited apps when categoryId is FAVORITES_CATEGORY.id', () => {
       const apps: SelfhostedApp[] = [
         createApp({ id: 'plex', name: 'Plex', favorite: true }),

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,0 +1,24 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardConfig, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
+
+import { ConfigService } from './config.service';
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  it('uses default settings before config loads and reacts to configured settings', () => {
+    const config = signal<DashboardConfig | undefined>(undefined);
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConfigService, useValue: { config } }],
+    });
+    const service = TestBed.inject(SettingsService);
+
+    expect(service.settings()).toBe(DEFAULT_DASHBOARD_CONFIG.settings);
+
+    const settings = { ...DEFAULT_DASHBOARD_CONFIG.settings, theme: 'light' as const };
+    config.set({ ...DEFAULT_DASHBOARD_CONFIG, settings });
+
+    expect(service.settings()).toBe(settings);
+  });
+});


### PR DESCRIPTION
## Summary

- Add direct behavior coverage for bookmark, config, metadata, and settings signal services
- Expand AppService and CategoryService state/projection coverage
- Expand SearchService query, engine, category, description, tag, and case behavior coverage

## Changes

| Area | Change |
|------|--------|
| Bookmark, Config, Metadata, Settings | Add direct specs for defaults and reactive projections |
| AppService | Cover config exposure, setters, filtering delegation, lookup, and category behavior |
| SearchService | Cover query/engine state and filtering dimensions |
| CategoryService | Cover undefined config, bookmarks, favorites, fallback, and selection |

## Test plan

- [x] Focused signal-service suite — 29/29 passed
- [x] Full Angular suite — 143/143 passed
- [x] Guard tests — 11/11 passed
- [x] Formatting, ESLint, and `git diff --check` passed

## Chain context

```text
✅ PR 1: IconService behavior coverage (#51)
✅ PR 2: Theme and YAML boundary coverage (#52)
📍 PR 3: Signal-state service coverage
   PR 4: Coverage threshold and CI artifacts
```

**Start state:** Several small signal services had no direct specs and larger services lacked important public state/filter coverage.
**End state:** Seven service specs protect defaults, reactive projections, state updates, delegation, and filtering behavior.
**Dependency:** PRs #51 and #52, already merged into `develop`.
**Follow-up:** Install the coverage provider, measure the target folders, enforce 70% statement coverage, and upload CI artifacts.
**Out of scope:** Production fix for padded non-empty search queries.
**Rollback:** Revert the seven modified or added service spec files.

Closes #38