### PR TITLE
feat(notifications): add signal state service

### DIFF
--- a/src/app/core/services/notification.service.spec.ts
+++ b/src/app/core/services/notification.service.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  NOTIFICATION_DURATION_MS,
+  Notification,
+  NotificationService,
+} from './notification.service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({ providers: [NotificationService] });
+    service = TestBed.inject(NotificationService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.useRealTimers();
+  });
+
+  it('retains all notification levels for consumers that mount later', () => {
+    service.error('Error');
+    service.warning('Warning');
+    service.info('Info');
+    service.success('Success');
+
+    expect(service.notifications()).toEqual([
+      { id: 1, level: 'error', message: 'Error' },
+      { id: 2, level: 'warning', message: 'Warning' },
+      { id: 3, level: 'info', message: 'Info' },
+      { id: 4, level: 'success', message: 'Success' },
+    ]);
+  });
+
+  it('assigns distinct monotonic IDs and preserves same-message notifications', () => {
+    service.error('Repeated failure');
+    service.error('Repeated failure');
+    service.dismiss(1);
+    service.error('Repeated failure');
+
+    expect(service.notifications()).toEqual([
+      { id: 2, level: 'error', message: 'Repeated failure' },
+      { id: 3, level: 'error', message: 'Repeated failure' },
+    ]);
+  });
+
+  it('trims messages and rejects blank notifications', () => {
+    service.info('  Ready  ');
+    service.warning('   ');
+
+    expect(service.notifications()).toEqual([{ id: 1, level: 'info', message: 'Ready' }]);
+  });
+
+  it('auto-dismisses only after the shared duration', () => {
+    service.success('Saved');
+
+    vi.advanceTimersByTime(NOTIFICATION_DURATION_MS - 1);
+    expect(service.notifications()).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(service.notifications()).toEqual([]);
+  });
+
+  it('cancels manual-dismiss timers without affecting later notifications', () => {
+    service.info('First');
+    vi.advanceTimersByTime(1000);
+    service.dismiss(1);
+    service.info('Second');
+
+    vi.advanceTimersByTime(NOTIFICATION_DURATION_MS - 1000);
+    expect(service.notifications().map(({ message }) => message)).toEqual(['Second']);
+
+    vi.advanceTimersByTime(1000);
+    expect(service.notifications()).toEqual([]);
+  });
+
+  it('caps the queue at five and evicts the oldest notification', () => {
+    for (let index = 1; index <= 6; index++) service.info(`Message ${index}`);
+
+    expect(service.notifications().map(({ id }) => id)).toEqual([2, 3, 4, 5, 6]);
+    expect(vi.getTimerCount()).toBe(5);
+  });
+
+  it('prevents consumers from mutating records or bypassing the queue cap', () => {
+    for (let index = 1; index <= 5; index++) service.info(`Message ${index}`);
+    const snapshot = service.notifications();
+    const injected: Notification = Object.freeze({ id: 999, level: 'error', message: 'Injected' });
+
+    expect(Reflect.set(snapshot[0], 'message', 'Tampered')).toBe(false);
+    expect(Reflect.set(snapshot, snapshot.length, injected)).toBe(false);
+    expect(Reflect.deleteProperty(snapshot, '0')).toBe(false);
+
+    service.info('Message 6');
+
+    expect(service.notifications().map(({ id }) => id)).toEqual([2, 3, 4, 5, 6]);
+    expect(service.notifications().map(({ message }) => message)).toEqual([
+      'Message 2',
+      'Message 3',
+      'Message 4',
+      'Message 5',
+      'Message 6',
+    ]);
+  });
+
+  it('cleans pending timers when its injector is destroyed', () => {
+    service.error('Pending');
+    service.info('Also pending');
+
+    TestBed.resetTestingModule();
+
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(NOTIFICATION_DURATION_MS);
+    expect(service.notifications()).toHaveLength(2);
+  });
+});

--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -1,0 +1,86 @@
+import { computed, DestroyRef, inject, Injectable, signal, Signal } from '@angular/core';
+
+export type NotificationLevel = 'error' | 'warning' | 'info' | 'success';
+
+export interface Notification {
+  readonly id: number;
+  readonly level: NotificationLevel;
+  readonly message: string;
+}
+
+export const NOTIFICATION_DURATION_MS = 5000;
+
+const MAX_ACTIVE_NOTIFICATIONS = 5;
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly notificationsState = signal<Notification[]>([]);
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+  private nextId = 1;
+
+  readonly notifications: Signal<readonly Notification[]> = computed(() =>
+    Object.freeze([...this.notificationsState()]),
+  );
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      for (const timer of this.timers.values()) clearTimeout(timer);
+      this.timers.clear();
+    });
+  }
+
+  error(message: string): void {
+    this.add('error', message);
+  }
+
+  warning(message: string): void {
+    this.add('warning', message);
+  }
+
+  info(message: string): void {
+    this.add('info', message);
+  }
+
+  success(message: string): void {
+    this.add('success', message);
+  }
+
+  dismiss(id: number): void {
+    const timer = this.timers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+    this.notificationsState.update((notifications) =>
+      notifications.filter((notification) => notification.id !== id),
+    );
+  }
+
+  private add(level: NotificationLevel, message: string): void {
+    const normalizedMessage = message.trim();
+    if (!normalizedMessage) return;
+
+    const notification: Notification = Object.freeze({
+      id: this.nextId++,
+      level,
+      message: normalizedMessage,
+    });
+    const notifications = this.notificationsState();
+
+    if (notifications.length === MAX_ACTIVE_NOTIFICATIONS) {
+      this.dismiss(notifications[0].id);
+    }
+
+    this.notificationsState.update((active) => [...active, notification]);
+    this.timers.set(
+      notification.id,
+      setTimeout(() => {
+        this.timers.delete(notification.id);
+        this.notificationsState.update((active) =>
+          active.filter(({ id }) => id !== notification.id),
+        );
+      }, NOTIFICATION_DURATION_MS),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add a signal-backed notification state and lifecycle contract
- Support error, warning, info, and success notifications
- Protect queue invariants with immutable snapshots, timer cleanup, and a five-item cap

## Changes

| File | Change |
|------|--------|
| `src/app/core/services/notification.service.ts` | Adds typed notification state, lifecycle, dismissal, and queue management |
| `src/app/core/services/notification.service.spec.ts` | Covers levels, IDs, duplicates, timers, eviction, destruction, and immutability |

## Test plan

- [x] Focused NotificationService tests — 8/8 passed
- [x] Full Angular suite — 151/151 passed
- [x] Guard tests — 11/11 passed
- [x] Lint, formatting, production build, and diff checks passed

## Chain context

```text
📍 PR 1: Notification state and lifecycle
   PR 2: Accessible toast UI
   PR 3: YAML retry and initialization ownership
   PR 4: Theme persistence notifications
   PR 5: Global ErrorHandler and conventions
```

**Start state:** The application had no user-facing notification state contract.
**End state:** Producers can enqueue typed notifications safely before the UI mounts, with deterministic lifecycle and bounded state.
**Dependency:** None; based directly on `develop`.
**Follow-up:** Add the accessible root-level toast consumer.
**Out of scope:** UI rendering, error-path wiring, retry logic, persistence notifications, and global ErrorHandler.
**Rollback:** Remove the two NotificationService files.

Closes #37