### PR TITLE
feat(notifications): add accessible toast UI

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,2 @@
 <app-dashboard class="text-neutral-800 dark:text-white"></app-dashboard>
+<app-toast></app-toast>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { App } from './app';
+import { AppToastComponent } from './shared/components/app-toast/app-toast.component';
+import { DashboardComponent } from './views/dashboard/dashboard.component';
+
+@Component({ selector: 'app-dashboard', template: '' })
+class DashboardStubComponent {}
+
+@Component({ selector: 'app-toast', template: '' })
+class AppToastStubComponent {}
+
+describe('App', () => {
+  it('composes the dashboard and toast host exactly once at the root', async () => {
+    await TestBed.configureTestingModule({ imports: [App] })
+      .overrideComponent(App, {
+        remove: { imports: [DashboardComponent, AppToastComponent] },
+        add: { imports: [DashboardStubComponent, AppToastStubComponent] },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('app-dashboard')).toHaveLength(1);
+    expect(fixture.nativeElement.querySelectorAll('app-toast')).toHaveLength(1);
+  });
+});

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { DashboardComponent } from './views/dashboard/dashboard.component';
+import { AppToastComponent } from './shared/components/app-toast/app-toast.component';
 
 @Component({
   selector: 'app-root',
-  imports: [DashboardComponent],
+  imports: [DashboardComponent, AppToastComponent],
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/components/app-toast/app-toast.component.css
+++ b/src/app/shared/components/app-toast/app-toast.component.css
@@ -1,0 +1,122 @@
+:host {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  width: min(24rem, calc(100vw - 2rem));
+  pointer-events: none;
+}
+
+.toast-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  color: #171717;
+  background: rgb(255 255 255 / 95%);
+  border: 1px solid rgb(255 255 255 / 70%);
+  border-left: 0.375rem solid;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 2rem rgb(0 0 0 / 25%);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+}
+
+.toast-error {
+  border-left-color: #b91c1c;
+}
+
+.toast-warning {
+  border-left-color: #a16207;
+}
+
+.toast-info {
+  border-left-color: #0369a1;
+}
+
+.toast-success {
+  border-left-color: #15803d;
+}
+
+.toast-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.toast-level {
+  display: block;
+  margin-bottom: 0.125rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.toast-message {
+  margin: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
+}
+
+.toast-dismiss {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: none;
+  place-items: center;
+  border: 0;
+  border-radius: 0.375rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.toast-dismiss:hover {
+  background: rgb(0 0 0 / 10%);
+}
+
+.toast-dismiss:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
+:host-context(.dark) .toast {
+  color: #fafafa;
+  background: rgb(23 23 23 / 95%);
+  border-color: rgb(255 255 255 / 20%);
+}
+
+:host-context(.dark) .toast-error {
+  border-left-color: #f87171;
+}
+
+:host-context(.dark) .toast-warning {
+  border-left-color: #facc15;
+}
+
+:host-context(.dark) .toast-info {
+  border-left-color: #38bdf8;
+}
+
+:host-context(.dark) .toast-success {
+  border-left-color: #4ade80;
+}
+
+:host-context(.dark) .toast-dismiss:hover {
+  background: rgb(255 255 255 / 12%);
+}
+
+@media (max-width: 40rem) {
+  :host {
+    top: 0.75rem;
+    right: 0.75rem;
+    width: calc(100vw - 1.5rem);
+  }
+}

--- a/src/app/shared/components/app-toast/app-toast.component.html
+++ b/src/app/shared/components/app-toast/app-toast.component.html
@@ -1,0 +1,28 @@
+<div class="toast-stack" aria-label="Notifications">
+  @for (notification of notifications(); track notification.id) {
+    <div
+      class="toast"
+      [class.toast-error]="notification.level === 'error'"
+      [class.toast-warning]="notification.level === 'warning'"
+      [class.toast-info]="notification.level === 'info'"
+      [class.toast-success]="notification.level === 'success'"
+      [attr.role]="notification.level === 'error' ? 'alert' : 'status'"
+    >
+      <div class="toast-content">
+        <strong class="toast-level">{{ notification.level }}</strong>
+        <p class="toast-message">{{ notification.message }}</p>
+      </div>
+      <button
+        #dismissButton
+        class="toast-dismiss"
+        type="button"
+        [attr.aria-label]="
+          'Dismiss ' + notification.level + ' notification: ' + notification.message
+        "
+        (click)="dismiss(notification.id)"
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  }
+</div>

--- a/src/app/shared/components/app-toast/app-toast.component.spec.ts
+++ b/src/app/shared/components/app-toast/app-toast.component.spec.ts
@@ -1,0 +1,161 @@
+import { signal } from '@angular/core';
+import { render, screen, waitFor, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { Notification, NotificationService } from '../../../core/services/notification.service';
+import { expectNoAxeViolations } from '../../../../testing/a11y';
+import { AppToastComponent } from './app-toast.component';
+
+describe('AppToastComponent', () => {
+  const notifications = signal<readonly Notification[]>([]);
+  const dismiss = vi.fn((id: number) => {
+    notifications.update((active) => active.filter((notification) => notification.id !== id));
+  });
+
+  const setup = async (initialNotifications: readonly Notification[] = []) => {
+    notifications.set(initialNotifications);
+    dismiss.mockReset();
+
+    return render(AppToastComponent, {
+      providers: [{ provide: NotificationService, useValue: { notifications, dismiss } }],
+    });
+  };
+
+  it('renders no live regions or dismiss buttons when empty', async () => {
+    await setup();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders all levels in deterministic service order with visible labels', async () => {
+    await setup([
+      { id: 4, level: 'error', message: 'Could not load apps' },
+      { id: 7, level: 'warning', message: 'Using cached settings' },
+      { id: 8, level: 'info', message: 'Refreshing dashboard' },
+      { id: 12, level: 'success', message: 'Dashboard ready' },
+    ]);
+
+    expect(
+      screen.getAllByText(/Could not|Using|Refreshing|ready/).map(({ textContent }) => textContent),
+    ).toEqual([
+      'Could not load apps',
+      'Using cached settings',
+      'Refreshing dashboard',
+      'Dashboard ready',
+    ]);
+    expect(screen.getAllByText(/^(error|warning|info|success)$/i)).toHaveLength(4);
+  });
+
+  it('announces errors assertively and each non-error notification politely', async () => {
+    await setup([
+      { id: 1, level: 'error', message: 'Failure' },
+      { id: 2, level: 'warning', message: 'Caution' },
+      { id: 3, level: 'info', message: 'Update' },
+      { id: 4, level: 'success', message: 'Saved' },
+    ]);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Failure');
+    expect(screen.getAllByRole('status')).toHaveLength(3);
+    expect(screen.getByLabelText('Notifications')).not.toHaveAttribute('aria-live');
+  });
+
+  it.each([
+    ['first', 1, 'Second'],
+    ['middle', 2, 'Third'],
+  ])(
+    'moves focus to the next dismiss button after dismissing the %s toast',
+    async (_, id, next) => {
+      const user = userEvent.setup();
+      await setup([
+        { id: 1, level: 'info', message: 'First' },
+        { id: 2, level: 'warning', message: 'Second' },
+        { id: 3, level: 'success', message: 'Third' },
+      ]);
+      const button = screen.getByRole('button', {
+        name: new RegExp(id === 1 ? 'First' : 'Second'),
+      });
+
+      button.focus();
+      await user.keyboard('{Enter}');
+
+      expect(dismiss).toHaveBeenCalledWith(id);
+      expect(
+        screen.queryByRole('button', { name: new RegExp(id === 1 ? 'First' : 'Second') }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: new RegExp(next) })).toHaveFocus();
+    },
+  );
+
+  it('moves focus to the previous dismiss button after dismissing the last toast', async () => {
+    const user = userEvent.setup();
+    await setup([
+      { id: 1, level: 'info', message: 'First' },
+      { id: 2, level: 'success', message: 'Last' },
+    ]);
+
+    await user.click(screen.getByRole('button', { name: /Last/ }));
+
+    expect(screen.getByRole('button', { name: /First/ })).toHaveFocus();
+  });
+
+  it('does not force focus elsewhere when dismissing the sole toast', async () => {
+    const user = userEvent.setup();
+    await setup([{ id: 1, level: 'info', message: 'Only' }]);
+
+    await user.click(screen.getByRole('button', { name: /Only/ }));
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('does not steal focus when notification state changes outside button dismissal', async () => {
+    await setup([
+      { id: 1, level: 'info', message: 'Expiring' },
+      { id: 2, level: 'success', message: 'Remaining' },
+    ]);
+    const externalControl = document.createElement('button');
+    document.body.append(externalControl);
+    externalControl.focus();
+
+    try {
+      notifications.update((active) => active.filter(({ id }) => id !== 1));
+
+      await waitFor(() => expect(screen.queryByText('Expiring')).not.toBeInTheDocument());
+      expect(externalControl).toHaveFocus();
+    } finally {
+      externalControl.remove();
+    }
+  });
+
+  it('renders notifications that exist before the component mounts without moving focus', async () => {
+    const priorControl = document.createElement('button');
+    priorControl.textContent = 'Prior control';
+    document.body.append(priorControl);
+    priorControl.focus();
+
+    try {
+      await setup([{ id: 9, level: 'info', message: 'Already queued' }]);
+
+      expect(screen.getByRole('status')).toHaveTextContent('Already queued');
+      expect(priorControl).toHaveFocus();
+    } finally {
+      priorControl.remove();
+    }
+  });
+
+  it('has no detectable accessibility violations for a complete stack', async () => {
+    const view = await setup([
+      { id: 1, level: 'error', message: 'Failure' },
+      { id: 2, level: 'warning', message: 'Caution' },
+      { id: 3, level: 'info', message: 'Update' },
+      { id: 4, level: 'success', message: 'Saved' },
+    ]);
+
+    for (const button of screen.getAllByRole('button')) {
+      expect(within(button).getByText('×')).toHaveAttribute('aria-hidden', 'true');
+    }
+    await expectNoAxeViolations(view.container);
+  });
+});

--- a/src/app/shared/components/app-toast/app-toast.component.ts
+++ b/src/app/shared/components/app-toast/app-toast.component.ts
@@ -1,0 +1,43 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  Injector,
+  viewChildren,
+} from '@angular/core';
+
+import { NotificationService } from '../../../core/services/notification.service';
+
+@Component({
+  selector: 'app-toast',
+  templateUrl: './app-toast.component.html',
+  styleUrl: './app-toast.component.css',
+  host: {
+    class: 'app-toast',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppToastComponent {
+  private readonly notificationService = inject(NotificationService);
+  private readonly injector = inject(Injector);
+  private readonly dismissButtons = viewChildren<ElementRef<HTMLButtonElement>>('dismissButton');
+
+  protected readonly notifications = this.notificationService.notifications;
+
+  protected dismiss(id: number): void {
+    const notifications = this.notifications();
+    const dismissedIndex = notifications.findIndex((notification) => notification.id === id);
+    const focusIndex =
+      dismissedIndex === notifications.length - 1 ? dismissedIndex - 1 : dismissedIndex;
+
+    this.notificationService.dismiss(id);
+
+    if (focusIndex < 0 || notifications.length === 1) return;
+
+    afterNextRender(() => this.dismissButtons()[focusIndex]?.nativeElement.focus(), {
+      injector: this.injector,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Add an accessible root-level toast stack consuming NotificationService
- Provide assertive error and polite non-error announcements without queue-wide repetition
- Preserve predictable keyboard focus when users dismiss notifications

## Accessibility

- Visible non-color-only level labels
- Native dismiss buttons with descriptive accessible names and focus-visible styling
- First/middle dismissal focuses the next toast; last dismissal focuses the previous toast
- Sole and timer-driven removals do not force or steal focus
- AXE passes; static light/dark contrast exceeds 17:1

## Test plan

- [x] Focused toast/root tests — 11 passed
- [x] Full Angular suite — 162 passed
- [x] Guard tests — 11 passed
- [x] AXE, lint, formatting, production build, and diff checks passed
- [x] Real Firefox/dev-server runtime check passed

## Chain context

```text
✅ PR 1: Notification state and lifecycle (#55)
📍 PR 2: Accessible toast UI
   PR 3: YAML retry and initialization ownership
   PR 4: Theme persistence notifications
   PR 5: Global ErrorHandler and conventions
```

**Start state:** Notification state existed but had no user-facing consumer.
**End state:** Notifications render once at application root with accessible semantics and deterministic focus behavior.
**Dependency:** PR #55, already merged into `develop`.
**Follow-up:** Wire YAML retry/fallback and initializer errors to the notification system.
**Out of scope:** Error producers, retry logic, persistence warnings, global ErrorHandler, and changelog.
**Rollback:** Remove the AppToast component/root spec and revert the root import/template element.

Closes #37