### PR TITLE
feat(config): retry transient dashboard loads

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,14 +1,20 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import {
+  ApplicationConfig,
+  provideAppInitializer,
+  provideBrowserGlobalErrorListeners,
+} from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 
-import { DASHBOARD_INITIALIZER_PROVIDER } from './core/initializers/dashboard.initializer';
+import { initializeDashboard } from './core/initializers/dashboard.initializer';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    provideHttpClient(),
     provideRouter(routes),
-    DASHBOARD_INITIALIZER_PROVIDER,
+    provideAppInitializer(initializeDashboard),
   ],
 };

--- a/src/app/core/initializers/dashboard.initializer.spec.ts
+++ b/src/app/core/initializers/dashboard.initializer.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { ApplicationInitStatus, provideAppInitializer } from '@angular/core';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
 import { initializeDashboard } from './dashboard.initializer';
 import { YamlLoaderService } from '../services/yaml-loader.service';
 import { AppService } from '../services/app.service';
 import { LoggerService } from '../services/logger.service';
+import { NotificationService } from '../services/notification.service';
 import { DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
 
 describe('initializeDashboard', () => {
@@ -19,6 +21,7 @@ describe('initializeDashboard', () => {
   let appService: {
     initializeConfig: ReturnType<typeof vi.fn>;
   };
+  let notifications: { error: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     logger = {
@@ -32,24 +35,29 @@ describe('initializeDashboard', () => {
     appService = {
       initializeConfig: vi.fn(),
     };
+    notifications = { error: vi.fn() };
 
     TestBed.configureTestingModule({
-      providers: [{ provide: LoggerService, useValue: logger }],
+      providers: [
+        { provide: LoggerService, useValue: logger },
+        { provide: YamlLoaderService, useValue: yamlLoader },
+        { provide: AppService, useValue: appService },
+        { provide: NotificationService, useValue: notifications },
+      ],
     });
   });
 
-  it('should initialize config and log success when the dashboard loads', async () => {
+  it('registers a supported initializer and initializes config exactly once', async () => {
     yamlLoader.loadDashboardConfig.mockReturnValue(of(DEFAULT_DASHBOARD_CONFIG));
+    TestBed.configureTestingModule({ providers: [provideAppInitializer(initializeDashboard)] });
 
-    const initializer = TestBed.runInInjectionContext(() =>
-      initializeDashboard(
-        yamlLoader as unknown as YamlLoaderService,
-        appService as unknown as AppService,
-      ),
-    );
+    const status = TestBed.inject(ApplicationInitStatus) as ApplicationInitStatus & {
+      runInitializers(): void;
+    };
+    status.runInitializers();
+    await status.donePromise;
 
-    await initializer();
-
+    expect(yamlLoader.loadDashboardConfig).toHaveBeenCalledOnce();
     expect(logger.debug).toHaveBeenCalledWith(
       '[AppInitializer] Starting dashboard initialization...',
     );
@@ -58,20 +66,17 @@ describe('initializeDashboard', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it('should log and rethrow when dashboard initialization fails', async () => {
+  it('installs defaults and completes when an unexpected loader error escapes', async () => {
     const initError = new Error('load failed');
     yamlLoader.loadDashboardConfig.mockReturnValue(throwError(() => initError));
 
-    const initializer = TestBed.runInInjectionContext(() =>
-      initializeDashboard(
-        yamlLoader as unknown as YamlLoaderService,
-        appService as unknown as AppService,
-      ),
-    );
+    const result = TestBed.runInInjectionContext(() => firstValueFrom(initializeDashboard()));
 
-    await expect(initializer()).rejects.toThrow(initError);
+    await expect(result).resolves.toBeUndefined();
 
-    expect(appService.initializeConfig).not.toHaveBeenCalled();
+    expect(appService.initializeConfig).toHaveBeenCalledOnce();
+    expect(appService.initializeConfig).toHaveBeenCalledWith(DEFAULT_DASHBOARD_CONFIG);
+    expect(notifications.error).toHaveBeenCalledOnce();
     expect(logger.error).toHaveBeenCalledWith(
       '[AppInitializer] Failed to initialize dashboard:',
       initError,

--- a/src/app/core/initializers/dashboard.initializer.ts
+++ b/src/app/core/initializers/dashboard.initializer.ts
@@ -1,43 +1,33 @@
-import { inject, Provider } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { inject } from '@angular/core';
+import { catchError, map, Observable, of, tap } from 'rxjs';
 
 import { YamlLoaderService } from '../services/yaml-loader.service';
 import { AppService } from '../services/app.service';
 import { LoggerService } from '../services/logger.service';
+import { NotificationService } from '../services/notification.service';
+import { DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
 
 /**
- * Factory function to initialize dashboard configuration
- * @param yamlLoader - YamlLoaderService instance
- * @param appService - AppService instance
- * @returns Function that returns a promise when initialization is complete
+ * Loads and installs dashboard configuration before root bootstrap completes.
  */
-export function initializeDashboard(
-  yamlLoader: YamlLoaderService,
-  appService: AppService,
-): () => Promise<void> {
+export function initializeDashboard(): Observable<void> {
+  const yamlLoader = inject(YamlLoaderService);
+  const appService = inject(AppService);
   const logger = inject(LoggerService);
+  const notifications = inject(NotificationService);
 
-  return async () => {
-    logger.debug('[AppInitializer] Starting dashboard initialization...');
-
-    return firstValueFrom(yamlLoader.loadDashboardConfig())
-      .then((config) => {
-        appService.initializeConfig(config);
-        logger.info('[AppInitializer] Dashboard initialized successfully');
-      })
-      .catch((error) => {
-        logger.error('[AppInitializer] Failed to initialize dashboard:', error);
-        throw error;
-      });
-  };
+  logger.debug('[AppInitializer] Starting dashboard initialization...');
+  return yamlLoader.loadDashboardConfig().pipe(
+    tap((config) => {
+      appService.initializeConfig(config);
+      logger.info('[AppInitializer] Dashboard initialized successfully');
+    }),
+    map(() => undefined),
+    catchError((error) => {
+      logger.error('[AppInitializer] Failed to initialize dashboard:', error);
+      notifications.error('Dashboard startup failed. Using defaults.');
+      appService.initializeConfig(DEFAULT_DASHBOARD_CONFIG);
+      return of(undefined);
+    }),
+  );
 }
-
-/**
- * Provider for APP_INITIALIZER to load dashboard config on app start
- */
-export const DASHBOARD_INITIALIZER_PROVIDER: Provider = {
-  provide: [],
-  useFactory: initializeDashboard,
-  deps: [YamlLoaderService, AppService],
-  multi: true,
-};

--- a/src/app/core/services/app.service.spec.ts
+++ b/src/app/core/services/app.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { of } from 'rxjs';
 
 import { AppService } from './app.service';
 import { ConfigService } from './config.service';
@@ -23,6 +22,7 @@ describe('AppService', () => {
   let configState: ReturnType<typeof signal<DashboardConfig | undefined>>;
   let searchService: SearchService;
   let categoryService: CategoryService;
+  let loadDashboardConfig: ReturnType<typeof vi.fn>;
 
   const createConfig = (overrides: Partial<DashboardConfig> = {}): DashboardConfig => ({
     ...DEFAULT_DASHBOARD_CONFIG,
@@ -31,6 +31,7 @@ describe('AppService', () => {
 
   beforeEach(() => {
     configState = signal<DashboardConfig | undefined>(createConfig());
+    loadDashboardConfig = vi.fn();
 
     TestBed.configureTestingModule({
       providers: [
@@ -46,9 +47,7 @@ describe('AppService', () => {
         },
         {
           provide: YamlLoaderService,
-          useValue: {
-            loadDashboardConfig: () => of(createConfig()),
-          },
+          useValue: { loadDashboardConfig },
         },
         {
           provide: BookmarkService,
@@ -62,6 +61,11 @@ describe('AppService', () => {
     service = TestBed.inject(AppService);
     searchService = TestBed.inject(SearchService);
     categoryService = TestBed.inject(CategoryService);
+  });
+
+  it('performs no YAML I/O when constructed', () => {
+    expect(service).toBeTruthy();
+    expect(loadDashboardConfig).not.toHaveBeenCalled();
   });
 
   describe('apps$', () => {

--- a/src/app/core/services/app.service.ts
+++ b/src/app/core/services/app.service.ts
@@ -10,7 +10,6 @@ import {
   FAVORITES_CATEGORY,
 } from '../models/dashboard.models';
 
-import { YamlLoaderService } from './yaml-loader.service';
 import { ConfigService } from './config.service';
 import { SearchService } from './search.service';
 import { CategoryService } from './category.service';
@@ -24,7 +23,6 @@ import { LoggerService } from './logger.service';
 @Injectable({ providedIn: 'root' })
 export class AppService {
   private configService = inject(ConfigService);
-  private yamlLoader = inject(YamlLoaderService);
   private searchService = inject(SearchService);
   private categoryService = inject(CategoryService);
   private bookmarkService = inject(BookmarkService);
@@ -50,12 +48,6 @@ export class AppService {
       ).sort((a, b) => a.name.localeCompare(b.name)),
     ];
   });
-
-  constructor() {
-    this.yamlLoader
-      .loadDashboardConfig()
-      .subscribe((config) => this.configService.fireNewSubject(config));
-  }
 
   /**
    * Computed: Filtered apps based on search and category

--- a/src/app/core/services/yaml-loader.service.spec.ts
+++ b/src/app/core/services/yaml-loader.service.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
-import { firstValueFrom, of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { defer, firstValueFrom, of, throwError } from 'rxjs';
 
 import { YamlLoaderService } from './yaml-loader.service';
 import { YamlParserService } from './yaml-parser.service';
 import { LoggerService } from './logger.service';
+import { NotificationService } from './notification.service';
 
 import { DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
 
@@ -21,6 +23,7 @@ describe('YamlLoaderService', () => {
     warn: ReturnType<typeof vi.fn>;
     error: ReturnType<typeof vi.fn>;
   };
+  let notifications: { warning: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     httpClient = {
@@ -37,6 +40,7 @@ describe('YamlLoaderService', () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
+    notifications = { warning: vi.fn() };
 
     TestBed.configureTestingModule({
       providers: [
@@ -44,11 +48,14 @@ describe('YamlLoaderService', () => {
         { provide: HttpClient, useValue: httpClient },
         { provide: YamlParserService, useValue: yamlParser },
         { provide: LoggerService, useValue: logger },
+        { provide: NotificationService, useValue: notifications },
       ],
     });
 
     service = TestBed.inject(YamlLoaderService);
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it('should log debug and info on successful config load', async () => {
     const config = {
@@ -73,6 +80,7 @@ describe('YamlLoaderService', () => {
 
     await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(config);
 
+    expect(httpClient.get).toHaveBeenCalledOnce();
     expect(logger.debug).toHaveBeenCalledWith('[YamlLoader] YAML content loaded successfully');
     expect(logger.info).toHaveBeenCalledWith('[YamlLoader] Dashboard config loaded:', {
       title: config.metadata.title,
@@ -83,8 +91,9 @@ describe('YamlLoaderService', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it('should log error and warn before falling back to default config', async () => {
-    const loadError = new Error('missing dashboard.yaml');
+  it('falls back immediately for a non-retryable HTTP error', async () => {
+    vi.useFakeTimers();
+    const loadError = new HttpErrorResponse({ status: 404 });
 
     httpClient.get.mockReturnValue(throwError(() => loadError));
 
@@ -98,26 +107,82 @@ describe('YamlLoaderService', () => {
     );
     expect(logger.warn).toHaveBeenCalledWith('[YamlLoader] Falling back to default configuration');
     expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
+    expect(notifications.warning).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('falls back when parsing loaded YAML fails', async () => {
-    const parseError = new Error('invalid dashboard config');
-    httpClient.get.mockReturnValue(of('invalid-yaml'));
-    yamlParser.parseYamlOrThrow.mockImplementation(() => {
-      throw parseError;
-    });
+  it('retries transient HTTP failures after 250ms and 500ms before succeeding', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    httpClient.get.mockReturnValue(
+      defer(() => {
+        attempts++;
+        return attempts < 3
+          ? throwError(() => new HttpErrorResponse({ status: 503 }))
+          : of('yaml-content');
+      }),
+    );
+    yamlParser.parseYamlOrThrow.mockReturnValue(DEFAULT_DASHBOARD_CONFIG);
 
-    await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(
-      DEFAULT_DASHBOARD_CONFIG,
+    const result = firstValueFrom(service.loadDashboardConfig());
+    expect(attempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(attempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(attempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(499);
+    expect(attempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toEqual(DEFAULT_DASHBOARD_CONFIG);
+    expect(attempts).toBe(3);
+    expect(notifications.warning).not.toHaveBeenCalled();
+  });
+
+  it('retries transient HTTP failures three times before one fallback', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    httpClient.get.mockReturnValue(
+      defer(() => {
+        attempts++;
+        return throwError(() => new HttpErrorResponse({ status: 0 }));
+      }),
     );
 
-    expect(yamlParser.parseYamlOrThrow).toHaveBeenCalledWith('invalid-yaml');
-    expect(logger.error).toHaveBeenCalledWith(
-      '[YamlLoader] Failed to load dashboard config:',
-      parseError,
-    );
+    const result = firstValueFrom(service.loadDashboardConfig());
+    await vi.advanceTimersByTimeAsync(250 + 500 + 999);
+    expect(attempts).toBe(3);
+    expect(notifications.warning).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toEqual(DEFAULT_DASHBOARD_CONFIG);
+    expect(attempts).toBe(4);
+    expect(notifications.warning).toHaveBeenCalledOnce();
     expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
   });
+
+  it.each([new Error('invalid YAML syntax'), new Error('invalid Zod schema')])(
+    'does not retry parser failure: %s',
+    async (parseError) => {
+      httpClient.get.mockReturnValue(of('invalid-yaml'));
+      yamlParser.parseYamlOrThrow.mockImplementation(() => {
+        throw parseError;
+      });
+
+      await expect(firstValueFrom(service.loadDashboardConfig())).resolves.toEqual(
+        DEFAULT_DASHBOARD_CONFIG,
+      );
+
+      expect(yamlParser.parseYamlOrThrow).toHaveBeenCalledWith('invalid-yaml');
+      expect(logger.error).toHaveBeenCalledWith(
+        '[YamlLoader] Failed to load dashboard config:',
+        parseError,
+      );
+      expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
+      expect(notifications.warning).toHaveBeenCalledOnce();
+      expect(httpClient.get).toHaveBeenCalledOnce();
+    },
+  );
 
   it('reports whether the config resource exists', async () => {
     httpClient.head.mockReturnValueOnce(of(undefined));
@@ -128,21 +193,5 @@ describe('YamlLoaderService', () => {
 
     expect(httpClient.head).toHaveBeenCalledTimes(2);
     expect(httpClient.head).toHaveBeenCalledWith('/config/dashboard.yaml');
-  });
-
-  it('uses the outer fallback if the delegated load unexpectedly errors', async () => {
-    const outerError = new Error('unexpected outer failure');
-    vi.spyOn(service, 'loadDashboardConfig').mockReturnValue(throwError(() => outerError));
-
-    await expect(firstValueFrom(service.loadDashboardConfigWithFallback())).resolves.toEqual(
-      DEFAULT_DASHBOARD_CONFIG,
-    );
-
-    expect(logger.error).toHaveBeenCalledWith(
-      '[YamlLoader] All attempts failed, using default config:',
-      outerError,
-    );
-    expect(httpClient.get).not.toHaveBeenCalled();
-    expect(yamlParser.getDefaultConfig).toHaveBeenCalledOnce();
   });
 });

--- a/src/app/core/services/yaml-loader.service.ts
+++ b/src/app/core/services/yaml-loader.service.ts
@@ -1,9 +1,10 @@
 import { inject, Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { catchError, map, Observable, of, tap } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { catchError, map, Observable, of, retry, tap, throwError, timer } from 'rxjs';
 
 import { YamlParserService } from './yaml-parser.service';
 import { LoggerService } from './logger.service';
+import { NotificationService } from './notification.service';
 
 import { DashboardConfig } from '../models/dashboard.models';
 
@@ -16,6 +17,7 @@ export class YamlLoaderService {
   private readonly http = inject(HttpClient);
   private readonly yamlParser = inject(YamlParserService);
   private readonly logger = inject(LoggerService);
+  private readonly notifications = inject(NotificationService);
 
   private readonly CONFIG_PATH = '/config/dashboard.yaml';
 
@@ -25,6 +27,13 @@ export class YamlLoaderService {
    */
   loadDashboardConfig(): Observable<DashboardConfig> {
     return this.http.get(this.CONFIG_PATH, { responseType: 'text' }).pipe(
+      retry({
+        count: 3,
+        delay: (error: unknown, retryCount) =>
+          this.isTransientHttpError(error)
+            ? timer(250 * 2 ** (retryCount - 1))
+            : throwError(() => error),
+      }),
       tap(() => {
         this.logger.debug('[YamlLoader] YAML content loaded successfully');
       }),
@@ -42,19 +51,7 @@ export class YamlLoaderService {
       catchError((error) => {
         this.logger.error('[YamlLoader] Failed to load dashboard config:', error);
         this.logger.warn('[YamlLoader] Falling back to default configuration');
-        return of(this.yamlParser.getDefaultConfig());
-      }),
-    );
-  }
-
-  /**
-   * Load dashboard configuration with explicit error handling
-   * @returns Observable of DashboardConfig
-   */
-  loadDashboardConfigWithFallback(): Observable<DashboardConfig> {
-    return this.loadDashboardConfig().pipe(
-      catchError((error) => {
-        this.logger.error('[YamlLoader] All attempts failed, using default config:', error);
+        this.notifications.warning('Dashboard configuration could not be loaded. Using defaults.');
         return of(this.yamlParser.getDefaultConfig());
       }),
     );
@@ -68,6 +65,16 @@ export class YamlLoaderService {
     return this.http.head(this.CONFIG_PATH).pipe(
       map(() => true),
       catchError(() => of(false)),
+    );
+  }
+
+  private isTransientHttpError(error: unknown): error is HttpErrorResponse {
+    return (
+      error instanceof HttpErrorResponse &&
+      (error.status === 0 ||
+        error.status === 408 ||
+        error.status === 429 ||
+        (error.status >= 500 && error.status < 600))
     );
   }
 }


### PR DESCRIPTION
## Summary

- Make Angular app initialization the single owner of dashboard configuration loading
- Retry only transient HTTP failures with bounded exponential backoff
- Surface one user warning and safely fall back after final failure

## Retry policy

| Failure | Behavior |
|---------|----------|
| Network `0`, `408`, `429`, `5xx` | Retry after 250ms, 500ms, and 1000ms |
| `400`, `401`, `403`, `404` | Fall back immediately |
| YAML syntax/schema/non-HTTP error | Fall back immediately |
| Final failure | Log once, notify once, emit defaults once |

## Initialization

- Uses Angular `provideAppInitializer`
- Removes constructor-triggered AppService I/O
- Performs one configuration request sequence
- Unexpected initializer failures install defaults and complete bootstrap so the toast can render

## Test plan

- [x] Focused affected tests — 17 passed
- [x] Full Angular suite — 165 passed
- [x] Coverage threshold — 97.63% statements
- [x] Lint, formatting, production build, and diff checks passed
- [x] Dev server compiled and dashboard YAML was reachable

## Chain context

```text
✅ PR 1: Notification state and lifecycle (#55)
✅ PR 2: Accessible toast UI (#56)
📍 PR 3: YAML retry and initialization ownership
   PR 4: Theme persistence notifications
   PR 5: Global ErrorHandler and conventions
```

**Start state:** AppService performed constructor I/O, the initializer provider was invalid, and every YAML failure fell back without retry or user feedback.
**End state:** Bootstrap has one initialization owner, bounded transient retries, and exactly one final warning/fallback.
**Dependencies:** PRs #55 and #56, already merged into `develop`.
**Follow-up:** Add ThemeService persistence warnings, then the global ErrorHandler and conventions.
**Out of scope:** Theme persistence, global uncaught errors, AGENTS/changelog updates.
**Rollback:** Revert the seven changed configuration, initializer, loader, and AppService files.

Closes #37