### PR TITLE
feat(theme): notify persistence failures

### DIFF
--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -3,10 +3,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { DashboardSettings, DEFAULT_DASHBOARD_CONFIG } from '../models/dashboard.models';
 
+import { LoggerService } from './logger.service';
+import { NotificationService } from './notification.service';
 import { SettingsService } from './settings.service';
 import { ThemeService } from './theme.service';
 
 describe('ThemeService', () => {
+  const logger = { warn: vi.fn() };
+  const notifications = { warning: vi.fn() };
   let settings: ReturnType<typeof signal<DashboardSettings>>;
   let mediaQuery: MediaQueryList;
   let systemThemeChange: ((event: MediaQueryListEvent) => void) | undefined;
@@ -23,6 +27,7 @@ describe('ThemeService', () => {
   });
 
   beforeEach(() => {
+    vi.clearAllMocks();
     originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia');
     localStorage.clear();
     document.documentElement.classList.remove('dark');
@@ -53,6 +58,8 @@ describe('ThemeService', () => {
           provide: SettingsService,
           useValue: { settings: settings.asReadonly() },
         },
+        { provide: LoggerService, useValue: logger },
+        { provide: NotificationService, useValue: notifications },
       ],
     });
   });
@@ -62,7 +69,6 @@ describe('ThemeService', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('Access denied', 'SecurityError');
     });
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     const service = TestBed.inject(ThemeService);
     TestBed.flushEffects();
@@ -70,10 +76,17 @@ describe('ThemeService', () => {
     expect(service.getThemeMode()).toBe('dark');
     expect(service.getCurrentTheme()).toBe('dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
-    expect(warn).toHaveBeenCalledWith(
-      '[ThemeService] Failed to read theme from localStorage:',
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[ThemeService] Failed to read theme from localStorage',
       expect.objectContaining({ name: 'SecurityError' }),
     );
+    expect(notifications.warning).toHaveBeenCalledOnce();
+    expect(notifications.warning).toHaveBeenCalledWith(
+      'Unable to load your saved theme preference. Using the configured theme.',
+    );
+    expect(notifications.warning.mock.calls[0][0]).not.toContain('Access denied');
   });
 
   it('reconciles a delayed configured theme when no preference is stored', () => {
@@ -115,6 +128,8 @@ describe('ThemeService', () => {
     expect(localStorage.getItem('dashboard-theme')).toBe('dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(notifications.warning).not.toHaveBeenCalled();
   });
 
   it('toggles explicit and resolved auto themes', () => {
@@ -154,15 +169,23 @@ describe('ThemeService', () => {
     vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw failure;
     });
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     service.setThemeMode('dark');
 
+    expect(service.getThemeMode()).toBe('dark');
     expect(service.getCurrentTheme()).toBe('dark');
-    expect(warn).toHaveBeenCalledWith(
-      '[ThemeService] Failed to save theme to localStorage:',
-      failure,
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[ThemeService] Failed to save theme to localStorage',
+      expect.objectContaining({ name: 'QuotaExceededError' }),
     );
+    expect(notifications.warning).toHaveBeenCalledOnce();
+    expect(notifications.warning).toHaveBeenCalledWith(
+      'Unable to save your theme preference. Your selection will apply for this session.',
+    );
+    expect(notifications.warning.mock.calls[0][0]).not.toContain('Quota exceeded');
   });
 
   it('watches system changes and removes the exact listener during cleanup', () => {

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -2,6 +2,8 @@ import { effect, Injectable, inject } from '@angular/core';
 import { signal, computed, Signal } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
+import { LoggerService } from './logger.service';
+import { NotificationService } from './notification.service';
 import { SettingsService } from './settings.service';
 
 /**
@@ -25,6 +27,8 @@ export interface ThemeState {
 export class ThemeService {
   private readonly settingsService = inject(SettingsService);
   private readonly document = inject(DOCUMENT);
+  private readonly logger = inject(LoggerService);
+  private readonly notifications = inject(NotificationService);
 
   private readonly STORAGE_KEY = 'dashboard-theme';
 
@@ -180,7 +184,10 @@ export class ThemeService {
     try {
       localStorage.setItem(this.STORAGE_KEY, mode);
     } catch (error) {
-      console.warn('[ThemeService] Failed to save theme to localStorage:', error);
+      this.logger.warn('[ThemeService] Failed to save theme to localStorage', error);
+      this.notifications.warning(
+        'Unable to save your theme preference. Your selection will apply for this session.',
+      );
     }
   }
 
@@ -192,7 +199,10 @@ export class ThemeService {
     try {
       return (localStorage.getItem(this.STORAGE_KEY) as ThemeMode) || undefined;
     } catch (error) {
-      console.warn('[ThemeService] Failed to read theme from localStorage:', error);
+      this.logger.warn('[ThemeService] Failed to read theme from localStorage', error);
+      this.notifications.warning(
+        'Unable to load your saved theme preference. Using the configured theme.',
+      );
       return undefined;
     }
   }


### PR DESCRIPTION
## Summary

- Surface theme preference storage failures through the notification system
- Keep diagnostic exception details in LoggerService only
- Preserve current-session theme behavior when localStorage is unavailable

## Behavior

| Failure | User outcome |
|---------|--------------|
| Saved preference cannot be read | Configured/default theme remains active and one warning appears |
| Current preference cannot be written | Selected theme remains active for the session and one warning appears |
| Successful storage | No notification |

## Test plan

- [x] Focused ThemeService tests — 8/8 passed
- [x] Full Angular suite — 165/165 passed
- [x] Coverage threshold — 97.65% statements
- [x] Lint, formatting, production build, guard, and diff checks passed

## Chain context

```text
✅ PR 1: Notification state and lifecycle (#55)
✅ PR 2: Accessible toast UI (#56)
✅ PR 3: YAML retry and initialization ownership (#57)
📍 PR 4: Theme persistence notifications
   PR 5: Global ErrorHandler and conventions
```

**Start state:** Theme storage exceptions were only written through raw console warnings.
**End state:** Users receive safe warnings while theme state and DOM fallbacks remain functional.
**Dependencies:** PRs #55–#57, already merged into `develop`.
**Follow-up:** Add the global ErrorHandler, register it, document conventions, and update the final changelog.
**Out of scope:** Global error safety, YAML flow, UI changes, AGENTS, and changelog.
**Rollback:** Revert the ThemeService implementation and spec changes.

Closes #37