### PR TITLE
feat(errors): handle uncaught application failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,10 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Design services around a single responsibility
 - Use the `providedIn: 'root'` option for singleton services
 - Use the `inject()` function instead of constructor injection
+
+## Error Handling
+
+- Send diagnostics through `LoggerService`; show concise, user-safe copy through `NotificationService`.
+- Retry only transient operations. The final fallback owns one notification, and producers must not duplicate it.
+- Treat the global error handler as a last resort for uncaught errors, not a replacement for local recovery.
+- Do not use raw `console` calls except for the documented last-resort fallback in the global error handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
 - **Production Logging Cleanup**: Replaced development-only `console.log` usage in dashboard initialization and config loading flows with a centralized logger service, while removing the dashboard click debug log from production code.
 - **Accessible Search Engine Selector**: Extracted the selector into a focused component with keyboard navigation and predictable focus-based closing, while preserving the search query when a popup is blocked.
+- **Resilient Error Feedback**: Added accessible toast notifications, bounded retries for transient YAML failures, persistence warnings, and safe handling for uncaught application errors.
 
 ### Performance
 

--- a/src/app/app.config.spec.ts
+++ b/src/app/app.config.spec.ts
@@ -1,0 +1,17 @@
+import { ErrorHandler } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { appConfig } from './app.config';
+import { GlobalErrorHandler } from './core/errors/global-error-handler';
+
+describe('appConfig', () => {
+  it('resolves the custom handler and registers browser error forwarding', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    TestBed.configureTestingModule({ providers: appConfig.providers });
+    const handler = TestBed.inject(ErrorHandler);
+
+    expect(handler).toBeInstanceOf(GlobalErrorHandler);
+    expect(addEventListener).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(addEventListener).toHaveBeenCalledWith('unhandledrejection', expect.any(Function));
+  });
+});

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationConfig,
+  ErrorHandler,
   provideAppInitializer,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
@@ -9,10 +10,12 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 
 import { initializeDashboard } from './core/initializers/dashboard.initializer';
+import { GlobalErrorHandler } from './core/errors/global-error-handler';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
     provideHttpClient(),
     provideRouter(routes),
     provideAppInitializer(initializeDashboard),

--- a/src/app/core/errors/global-error-handler.spec.ts
+++ b/src/app/core/errors/global-error-handler.spec.ts
@@ -1,0 +1,104 @@
+import { ErrorHandler } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { GlobalErrorHandler } from './global-error-handler';
+import { LoggerService } from '../services/logger.service';
+import { NotificationService } from '../services/notification.service';
+
+describe('GlobalErrorHandler', () => {
+  let handler: ErrorHandler;
+  let logger: { error: ReturnType<typeof vi.fn> };
+  let notifications: { error: ReturnType<typeof vi.fn> };
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logger = { error: vi.fn() };
+    notifications = { error: vi.fn() };
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ErrorHandler, useClass: GlobalErrorHandler },
+        { provide: LoggerService, useValue: logger },
+        { provide: NotificationService, useValue: notifications },
+      ],
+    });
+    handler = TestBed.inject(ErrorHandler);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    ['string', 'string failure', 'string failure'],
+    ['object', { status: 503, source: 'config' }, '{"status":503,"source":"config"}'],
+    ['null', null, 'Unknown global error: null'],
+    ['undefined', undefined, 'Unknown global error: undefined'],
+  ])('normalizes a %s error for diagnostics', (_type, input, expectedMessage) => {
+    handler.handleError(input);
+
+    const diagnostic = logger.error.mock.calls[0][1];
+    expect(diagnostic).toBeInstanceOf(Error);
+    expect((diagnostic as Error).message).toBe(expectedMessage);
+  });
+
+  it('preserves Error diagnostics and keeps exception details out of the notification', () => {
+    const error = new Error('database credentials leaked');
+
+    handler.handleError(error);
+
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith('[GlobalErrorHandler] Unhandled error:', error);
+    expect(notifications.error).toHaveBeenCalledOnce();
+    expect(notifications.error).toHaveBeenCalledWith('An unexpected error occurred.');
+    expect(notifications.error.mock.calls[0][0]).not.toContain(error.message);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('unwraps Angular original errors for diagnostics', () => {
+    const original = new Error('original failure');
+
+    handler.handleError({ ngOriginalError: original });
+
+    expect(logger.error).toHaveBeenCalledWith('[GlobalErrorHandler] Unhandled error:', original);
+    expect(notifications.error).toHaveBeenCalledOnce();
+  });
+
+  it('still notifies without escaping when logging fails', () => {
+    logger.error.mockImplementation(() => {
+      throw new Error('logger failed');
+    });
+
+    expect(() => handler.handleError(new Error('application failed'))).not.toThrow();
+
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(notifications.error).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it('uses the fallback without escaping when notification fails', () => {
+    notifications.error.mockImplementation(() => {
+      throw new Error('notification failed');
+    });
+
+    expect(() => handler.handleError(new Error('application failed'))).not.toThrow();
+
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(notifications.error).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it('does not escape or recurse when both dependencies fail', () => {
+    logger.error.mockImplementation(() => {
+      throw new Error('logger failed');
+    });
+    notifications.error.mockImplementation(() => {
+      throw new Error('notification failed');
+    });
+
+    expect(() => handler.handleError(new Error('application failed'))).not.toThrow();
+
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(notifications.error).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/core/errors/global-error-handler.ts
+++ b/src/app/core/errors/global-error-handler.ts
@@ -1,0 +1,91 @@
+import { ErrorHandler, inject, Injectable } from '@angular/core';
+
+import { LoggerService } from '../services/logger.service';
+import { NotificationService } from '../services/notification.service';
+
+const SAFE_ERROR_MESSAGE = 'An unexpected error occurred.';
+const UNKNOWN_ERROR_MESSAGE = 'Unknown global error';
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+  private readonly logger = inject(LoggerService);
+  private readonly notifications = inject(NotificationService);
+
+  handleError(error: unknown): void {
+    const diagnostic = this.normalizeError(error);
+
+    try {
+      this.logger.error('[GlobalErrorHandler] Unhandled error:', diagnostic);
+    } catch (loggerError) {
+      this.fallback('[GlobalErrorHandler] Logger failed while handling an error:', {
+        diagnostic,
+        loggerError,
+      });
+    }
+
+    try {
+      this.notifications.error(SAFE_ERROR_MESSAGE);
+    } catch (notificationError) {
+      this.fallback('[GlobalErrorHandler] Notification failed while handling an error:', {
+        diagnostic,
+        notificationError,
+      });
+    }
+  }
+
+  private normalizeError(error: unknown): Error {
+    const originalError = this.unwrapAngularError(error);
+
+    if (originalError instanceof Error) return originalError;
+    if (typeof originalError === 'string') return new Error(originalError);
+    if (originalError === null) return new Error(`${UNKNOWN_ERROR_MESSAGE}: null`);
+    if (originalError === undefined) return new Error(`${UNKNOWN_ERROR_MESSAGE}: undefined`);
+
+    try {
+      const seen = new WeakSet<object>();
+      const serialized = JSON.stringify(originalError, (_key, value: unknown) => {
+        if (typeof value !== 'object' || value === null) return value;
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+        return value;
+      });
+      return new Error(serialized ?? this.safeString(originalError));
+    } catch {
+      return new Error(this.safeString(originalError));
+    }
+  }
+
+  private unwrapAngularError(error: unknown): unknown {
+    let current = error;
+    const seen = new Set<unknown>();
+
+    while (typeof current === 'object' && current !== null && !seen.has(current)) {
+      seen.add(current);
+      try {
+        const original = Reflect.get(current, 'ngOriginalError') as unknown;
+        if (original === undefined) break;
+        current = original;
+      } catch {
+        break;
+      }
+    }
+
+    return current;
+  }
+
+  private safeString(value: unknown): string {
+    try {
+      return String(value);
+    } catch {
+      return UNKNOWN_ERROR_MESSAGE;
+    }
+  }
+
+  private fallback(message: string, context: unknown): void {
+    try {
+      console.error(message, context);
+    } catch {
+      // The global handler must never propagate failures from its last-resort fallback.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a safe Angular GlobalErrorHandler for uncaught application failures
- Preserve diagnostics while showing one user-safe notification
- Document error-handling conventions and complete the issue #37 changelog entry

## Failure containment

- Logger and notifier failures are isolated independently
- `handleError` never rethrows
- Last-resort console fallback cannot recursively re-enter application services
- Error, string, object, circular, null/undefined, and Angular-wrapped errors normalize safely
- Existing browser `error` and `unhandledrejection` forwarding remains enabled without duplicate listeners

## Documentation

- `AGENTS.md` now defines diagnostics, notification ownership, retry, and console rules
- `CHANGELOG.md` records the complete outcome: toast UI, bounded YAML retries, persistence warnings, and uncaught-error handling

## Test plan

- [x] Focused handler/config tests — 10/10 passed
- [x] Full Angular suite — 175/175 passed
- [x] Guard tests — 11/11 passed
- [x] Coverage threshold — 97.65% statements
- [x] Lint, candidate formatting, production build, config parsing, and diff checks passed

## Chain context

```text
✅ PR 1: Notification state and lifecycle (#55)
✅ PR 2: Accessible toast UI (#56)
✅ PR 3: YAML retry and initialization ownership (#57)
✅ PR 4: Theme persistence notifications (#58)
📍 PR 5: Global ErrorHandler, conventions, and changelog
```

**Start state:** Uncaught browser/Angular errors had no safe application-level reporting boundary.
**End state:** Uncaught failures are diagnosed, safely notified, contained, documented, and reflected in release notes.
**Dependencies:** PRs #55–#58, already merged into `develop`.
**Follow-up:** None required for issue #37.
**Out of scope:** Dependency audit remediation and unrelated production defects.
**Rollback:** Remove the handler/spec/config spec and revert app config, AGENTS, and changelog changes.

Closes #37