### PR TITLE
docs(changelog): prepare v1.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-## Unreleased
+## v1.1.0
+
+### New Features
+
+- **Accessible Search Engine Selector**: Added a focused search engine selector with arrow, Home, End, and Escape keyboard navigation, predictable focus management, and focus-based closing.
+- **Resilient Error Feedback**: Added a signal-based notification service and accessible toast UI, bounded retries for transient dashboard loading failures, warnings when theme preferences cannot be persisted, and a safe fallback for uncaught application errors.
 
 ### Bug Fixes
 
 - **Sticky Header and Finder**: Header, finder, and categories now stay fixed while only the apps area scrolls, improving navigation when dealing with many applications.
 - **Production Logging Cleanup**: Replaced development-only `console.log` usage in dashboard initialization and config loading flows with a centralized logger service, while removing the dashboard click debug log from production code.
-- **Accessible Search Engine Selector**: Extracted the selector into a focused component with keyboard navigation and predictable focus-based closing, while preserving the search query when a popup is blocked.
-- **Resilient Error Feedback**: Added accessible toast notifications, bounded retries for transient YAML failures, persistence warnings, and safe handling for uncaught application errors.
+- **Search Popup Query Preservation**: Preserved the current search query when the browser blocks an external search popup.
 
 ### Performance
 
@@ -19,8 +23,11 @@
 - **Release Notes Template**: Fixed the `create-release.yml` workflow to respect the `.github/release.yml` configuration when generating release notes. Previously the workflow called the GitHub API directly without passing `configuration_file_path` and `configuration_file_name`, causing the custom categories and exclusions to be ignored.
 - **Node 22 LTS CI Runtime**: Pinned the GitHub Actions Node.js test workflow to Node 22 LTS and documented Node 22 LTS in the README as the recommended local version because it matches CI.
 - **Focused Test CI Guard**: Added a repository-level guard that fails pull request CI when committed focused tests such as `.only`, `fit`, `fdescribe`, or `.only.each(...)` are present, with regression coverage for the checker and its CLI contract.
-- **Automated Axe Accessibility Checks**: Added reusable axe-core assertions for covered `app-finder`, `app-card`, `app-categories`, and `dashboard` render states. Because CI already runs `npm test`, violations found by those checks now fail the existing test workflow automatically.
 - **ESLint and Scoped Source Formatting**: Added lint-staged ESLint autofixes for staged TypeScript, including `test-setup.ts`, and Prettier formatting for staged TypeScript, HTML, and SCSS. Pull request CI now enforces focused-test detection, linting, scoped formatting, tests, and the production build.
+
+### Testing & Quality
+
+- **Automated Axe Accessibility Checks**: Added reusable axe-core assertions for covered `app-finder`, `app-card`, `app-categories`, and `dashboard` render states. Because CI already runs `npm test`, violations found by those checks now fail the existing test workflow automatically.
 - **Core Coverage CI Gate**: Added behavior coverage for core services and initializers, reaching 97.31% statement coverage with a 70% CI threshold and uploaded coverage reports.
 
 ### Documentation
@@ -32,54 +39,93 @@
 
 ### Changed Files
 
+- `.github/workflows/create-release.yml`
 - `.github/workflows/test.yml`
+- `.husky/pre-commit`
 - `AGENTS.md`
-- `README.md`
+- `ARCHITECTURE.md`
 - `CHANGELOG.md`
-- `package.json`
-- `package-lock.json`
+- `README.md`
 - `angular.json`
 - `eslint.config.js`
-- `.husky/pre-commit`
+- `package-lock.json`
+- `package.json`
 - `scripts/check-focused-tests.mjs`
 - `scripts/check-focused-tests.test.mjs`
-- `src/testing/tooling-setup.spec.ts`
-- `src/testing/check-focused-tests-cli.spec.ts`
-- `src/testing/node-test-harness.d.ts`
-- `src/testing/a11y.ts`
+- `src/app/app.config.spec.ts`
+- `src/app/app.config.ts`
+- `src/app/app.html`
+- `src/app/app.spec.ts`
+- `src/app/app.ts`
+- `src/app/core/errors/global-error-handler.spec.ts`
+- `src/app/core/errors/global-error-handler.ts`
+- `src/app/core/initializers/dashboard.initializer.spec.ts`
 - `src/app/core/initializers/dashboard.initializer.ts`
+- `src/app/core/models/dashboard.models.ts`
 - `src/app/core/services/app.service.spec.ts`
 - `src/app/core/services/app.service.ts`
+- `src/app/core/services/bookmark.service.spec.ts`
 - `src/app/core/services/bookmark.service.ts`
 - `src/app/core/services/category.service.spec.ts`
 - `src/app/core/services/category.service.ts`
+- `src/app/core/services/config.service.spec.ts`
 - `src/app/core/services/config.service.ts`
-- `src/app/core/services/logger.service.ts`
+- `src/app/core/services/icon.service.spec.ts`
+- `src/app/core/services/icon.service.ts`
 - `src/app/core/services/logger.service.spec.ts`
+- `src/app/core/services/logger.service.ts`
+- `src/app/core/services/metadata.service.spec.ts`
 - `src/app/core/services/metadata.service.ts`
+- `src/app/core/services/notification.service.spec.ts`
+- `src/app/core/services/notification.service.ts`
 - `src/app/core/services/search.service.spec.ts`
 - `src/app/core/services/search.service.ts`
+- `src/app/core/services/settings.service.spec.ts`
 - `src/app/core/services/settings.service.ts`
 - `src/app/core/services/theme.service.spec.ts`
 - `src/app/core/services/theme.service.ts`
+- `src/app/core/services/yaml-loader.service.spec.ts`
 - `src/app/core/services/yaml-loader.service.ts`
-- `src/app/app.ts`
+- `src/app/core/services/yaml-parser.service.spec.ts`
+- `src/app/core/services/yaml-parser.service.ts`
 - `src/app/shared/components/app-card/app-card.component.html`
 - `src/app/shared/components/app-card/app-card.component.spec.ts`
 - `src/app/shared/components/app-card/app-card.component.ts`
-- `src/app/shared/components/app-clock/app-clock.component.spec.ts`
-- `src/app/shared/components/app-clock/app-clock.component.ts`
+- `src/app/shared/components/app-categories/app-categories.component.html`
 - `src/app/shared/components/app-categories/app-categories.component.spec.ts`
 - `src/app/shared/components/app-categories/app-categories.component.ts`
+- `src/app/shared/components/app-clock/app-clock.component.html`
+- `src/app/shared/components/app-clock/app-clock.component.spec.ts`
+- `src/app/shared/components/app-clock/app-clock.component.ts`
+- `src/app/shared/components/app-finder/app-finder.component.html`
 - `src/app/shared/components/app-finder/app-finder.component.spec.ts`
 - `src/app/shared/components/app-finder/app-finder.component.ts`
+- `src/app/shared/components/app-footer/app-footer.component.html`
 - `src/app/shared/components/app-footer/app-footer.component.ts`
 - `src/app/shared/components/app-header/app-header.component.spec.ts`
 - `src/app/shared/components/app-header/app-header.component.ts`
 - `src/app/shared/components/app-loading/app-loading.component.ts`
+- `src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.html`
+- `src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.spec.ts`
+- `src/app/shared/components/app-search-engine-selector/app-search-engine-selector.component.ts`
+- `src/app/shared/components/app-toast/app-toast.component.css`
+- `src/app/shared/components/app-toast/app-toast.component.html`
+- `src/app/shared/components/app-toast/app-toast.component.spec.ts`
+- `src/app/shared/components/app-toast/app-toast.component.ts`
 - `src/app/views/dashboard/dashboard.component.html`
 - `src/app/views/dashboard/dashboard.component.spec.ts`
 - `src/app/views/dashboard/dashboard.component.ts`
+- `src/index.html`
+- `src/main.ts`
+- `src/testing/a11y.ts`
+- `src/testing/check-focused-tests-cli.spec.ts`
+- `src/testing/node-test-harness.d.ts`
+- `src/testing/tooling-setup.spec.ts`
+- `tsconfig.spec.json`
+
+### Summary
+
+Minor release introducing new user-facing accessibility and error-feedback capabilities, alongside substantial reliability, performance, testing, and contributor-tooling improvements. There are no intentional breaking changes.
 
 ## v1.0.1
 


### PR DESCRIPTION
## Summary

- Mark the accumulated release notes as `v1.1.0` without a publication date
- Separate new features, bug fixes, performance, quality, tooling, and documentation
- Complete the changed-files inventory and add an accurate minor-release summary

## Intentional release state

- The publication date remains unset while the maintainer performs manual testing.
- `package.json` remains at `1.0.1`.
- No tag or release is created by this PR.
- The real date and package version bump will be applied only when publication is approved.

## Validation

- [x] 16 release entries classified exactly once
- [x] Changed Files matches `git diff --name-only v1.0.1..develop`
- [x] 83 expected paths, 83 listed, 0 missing, 0 extra, 0 duplicates
- [x] Candidate Markdown formatting passed
- [x] `git diff --check` passed
- [x] Previous release history remains unchanged

**Runtime harness:** N/A — documentation-only preparation.

Closes #61